### PR TITLE
Build SLN on Windows, don't make

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -25,21 +25,29 @@ if [ ! -d "lib/libuv/build" ]; then
     cp -Rf bin/gyp lib/libuv/build/gyp
 fi
 
-# Compiling wrk
-echo "----------------------------------------"
-echo "Compiling wrk"
-echo "----------------------------------------"
-cd bin/wrk
-make
-cd ../../
+if [ !PLATFORM_UNIX ]; then
+	echo "----------------------------------------"
+	echo "Creating Visual Studio solution"
+	echo "----------------------------------------"
+	
+	$GYP --depth=. -Dlibrary=static_library -Dtarget=ia32 haywire.gyp
+else
+	# Compiling wrk
+	echo "----------------------------------------"
+	echo "Compiling wrk"
+	echo "----------------------------------------"
+	cd bin/wrk
+	make
+	cd ../../
 
-echo "----------------------------------------"
-echo "Configuring for ${OS}"
-echo "----------------------------------------"
-$GYP -f make --depth=. -Dlibrary=static_library haywire.gyp
+	echo "----------------------------------------"
+	echo "Configuring for ${OS}"
+	echo "----------------------------------------"
+	$GYP -f make --depth=. -Dlibrary=static_library haywire.gyp
 
-echo "----------------------------------------"
-echo "Compiling Haywire"
-echo "----------------------------------------"
-./clean.sh
-make
+	echo "----------------------------------------"
+	echo "Compiling Haywire"
+	echo "----------------------------------------"
+	./clean.sh
+	make
+fi


### PR DESCRIPTION
Removed all calls to `make` during build process on windows - this is handled by VS.

My bash wizardry level is not very high, but I think I've got the gist of things. #worksforme!
