### PR TITLE
Enable C99 standard when building on Linux.

### DIFF
--- a/haywire.gyp
+++ b/haywire.gyp
@@ -33,6 +33,14 @@
           'src/haywire/trie/route_compare_method.h',
           'src/haywire/trie/route_compare_method.c'
         ],
+
+        'conditions': [
+          [ 'OS=="linux"', {
+            'cflags': [
+              '-std=c99',
+            ]
+          }],
+        ],
       }, # haywire static library
 
       ########################################


### PR DESCRIPTION
A better way to do this would be to check the compiler, rather than the OS,
but this works for now.
