### PR TITLE
Possible fix for high memory usage during large workloads

### DIFF
--- a/src/haywire/http_request.c
+++ b/src/haywire/http_request.c
@@ -115,7 +115,7 @@ int http_request_on_message_complete(http_parser* parser)
         length += bytes_added(sprintf(response->buffer + length, "Date: Fri, 26 Aug 2011 00:31:53 GMT" CRLF));
         length += bytes_added(sprintf(response->buffer + length, "Connection: Keep-Alive" CRLF));
         length += bytes_added(sprintf(response->buffer + length, "Content-Type: Haywire/master" CRLF));
-        length += bytes_added(sprintf(response->buffer + length, "Content-Length: %d" CRLF CRLF, strlen(response->body) + 3));
+        length += bytes_added(sprintf(response->buffer + length, "Content-Length: %lu" CRLF CRLF, strlen(response->body) + 3));
         length += bytes_added(sprintf(response->buffer + length, "%s" CRLF, response->body));
 
         http_server_write_response(parser, response);

--- a/src/haywire/http_request.c
+++ b/src/haywire/http_request.c
@@ -1,4 +1,6 @@
 #include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 #include "haywire.h"
 #include "http_request.h"
 #include "http_parser.h"

--- a/src/haywire/http_server.c
+++ b/src/haywire/http_server.c
@@ -5,6 +5,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include <assert.h>
 #include "uv.h"
 #include "haywire.h"

--- a/src/haywire/trie/route_compare_method.c
+++ b/src/haywire/trie/route_compare_method.c
@@ -1,6 +1,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <strings.h>
 #include "route_compare_method.h"
 #include "radix.h"
 

--- a/src/samples/hello_world/program.c
+++ b/src/samples/hello_world/program.c
@@ -1,3 +1,4 @@
+#include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -60,6 +61,8 @@ http_response *get_root(http_request *request)
 int main()
 {
     char route[] = "/";
+
+    signal(SIGPIPE, SIG_IGN);
 
     hw_http_add_route(route, get_root);
     hw_http_open("0.0.0.0", 8000);


### PR DESCRIPTION
I tested this patch only on Linux so results may vary. I used the following workload for all tests:

    ./wrk -d10 -t8 -c1024 --pipeline 64 http://127.0.0.1:8000

Prior to applying the patches, a large workload would cause what appeared to be a memory leak and high CPU usage, both of which lingered far after the client finished. In order to rule out memory leaks, I added several printf statements and enabled valgrind.

I didn't find any obvious memory leaks, but I found two possible causes for the memory issue by looking at the libuv mailing list.

First, when the client closes the connection before the server has a chance to write back all responses, the server will get an error. Prior to libuv 0.10.6, the server's event loop could get stuck in an infinite loop. Existing connections would remain open in the CLOSE_WAIT state; thus, all memory allocated during the lifetime of that connection would not be freed. This gave the impression that there was a memory leak. This issue was addressed around May 1st by the libuv developers; updating to the latest stable release (0.10.7) should fix this. I updated the libuv library in the pull request.

Second, if a server writes to a socket that has been closed on the client side, then the server will receive a SIGPIPE signal. The default behavior is to kill the resulting process. If you ignore the SIGPIPE signal, then this won't happen. I added a patch for this.

If you still see a high memory usage after applying the patches, run the following command (assuming you started the server on port 8000):

    netstat -a | grep CLOSE_WAIT | grep 8000 | wc -l

This will show all connections waiting to be closed by the server. It usually takes a few seconds to clear the connections so you may have to run the command again to track the progress. This behavior typically occurs when you run valgrind.