### PR TITLE
Tighten up our keep alive usage.

### DIFF
--- a/src/haywire/http_response.c
+++ b/src/haywire/http_response.c
@@ -35,6 +35,24 @@ void hw_set_http_version(hw_http_response* response, unsigned short major, unsig
     resp->http_minor = minor;
 }
 
+void hw_set_http_keep_alive(hw_http_response* response, int keep_alive)
+{
+    hw_string keep_alive_name;
+    hw_string keep_alive_value;
+
+    SETSTRING(keep_alive_name, "Connection");
+    if (keep_alive)
+    {
+        SETSTRING(keep_alive_value, "Keep-Alive");
+    }
+    else
+    {
+        SETSTRING(keep_alive_value, "close");
+    }
+
+    hw_set_response_header(response, &keep_alive_name, &keep_alive_value);
+}
+
 void hw_set_response_status_code(hw_http_response* response, hw_string* status_code)
 {
     http_response* resp = (http_response*)response;

--- a/src/haywire/http_server.h
+++ b/src/haywire/http_server.h
@@ -25,7 +25,6 @@ union stream_handle
 
 extern void* routes;
 extern uv_loop_t* uv_loop;
-extern hw_string* http_v1_0;
 extern hw_string* http_v1_1;
 extern hw_string* server_name;
 extern int listener_count;

--- a/src/haywire/server_stats.c
+++ b/src/haywire/server_stats.c
@@ -25,8 +25,6 @@ void get_server_stats(http_request* request, hw_http_response* response, void* u
     hw_string content_type_name;
     hw_string content_type_value;
     hw_string body;
-    hw_string keep_alive_name;
-    hw_string keep_alive_value;
     
     SETSTRING(status_code, HTTP_STATUS_200);
     hw_set_response_status_code(response, &status_code);
@@ -38,18 +36,6 @@ void get_server_stats(http_request* request, hw_http_response* response, void* u
     
     SETSTRING(body, "stats printed");
     hw_set_body(response, &body);
-    
-    if (request->keep_alive)
-    {
-        SETSTRING(keep_alive_name, "Connection");
-        
-        SETSTRING(keep_alive_value, "Keep-Alive");
-        hw_set_response_header(response, &keep_alive_name, &keep_alive_value);
-    }
-    else
-    {
-        hw_set_http_version(response, 1, 0);
-    }
     
     hw_http_response_send(response, NULL, NULL);
     

--- a/src/samples/hello_world/program.c
+++ b/src/samples/hello_world/program.c
@@ -15,8 +15,6 @@ void get_root(http_request* request, hw_http_response* response, void* user_data
     hw_string content_type_name;
     hw_string content_type_value;
     hw_string body;
-    hw_string keep_alive_name;
-    hw_string keep_alive_value;
     
     SETSTRING(status_code, HTTP_STATUS_200);
     hw_set_response_status_code(response, &status_code);
@@ -28,18 +26,6 @@ void get_root(http_request* request, hw_http_response* response, void* user_data
     
     SETSTRING(body, "hello world");
     hw_set_body(response, &body);
-    
-    if (request->keep_alive)
-    {
-        SETSTRING(keep_alive_name, "Connection");
-        
-        SETSTRING(keep_alive_value, "Keep-Alive");
-        hw_set_response_header(response, &keep_alive_name, &keep_alive_value);
-    }
-    else
-    {
-        hw_set_http_version(response, 1, 0);
-    }
     
     hw_http_response_send(response, "user_data", response_complete);
 }

--- a/src/samples/techempower_benchmark/program.c
+++ b/src/samples/techempower_benchmark/program.c
@@ -15,8 +15,6 @@ void get_plaintext(http_request* request, hw_http_response* response, void* user
     hw_string content_type_name;
     hw_string content_type_value;
     hw_string body;
-    hw_string keep_alive_name;
-    hw_string keep_alive_value;
     
     SETSTRING(status_code, HTTP_STATUS_200);
     hw_set_response_status_code(response, &status_code);
@@ -28,18 +26,6 @@ void get_plaintext(http_request* request, hw_http_response* response, void* user
     
     SETSTRING(body, "Hello, World!");
     hw_set_body(response, &body);
-    
-    if (request->keep_alive)
-    {
-        SETSTRING(keep_alive_name, "Connection");
-        
-        SETSTRING(keep_alive_value, "Keep-Alive");
-        hw_set_response_header(response, &keep_alive_name, &keep_alive_value);
-    }
-    else
-    {
-        hw_set_http_version(response, 1, 0);
-    }
     
     hw_http_response_send(response, NULL, response_complete);
 }


### PR DESCRIPTION
Provide the Connection (keep alive) header automatically for users.  They could conceivably override this -- it's set before the route callback is invoked -- but right now, headers are additive only... so that might be a problem down the line.  This at least gets things a little more streamlined.

Let me know what you think.  This should work OK with a HTTP/1.0 connection, I believe, if they send the right headers... but obviously HTTP/1.0 doesn't officially support keep alives.