### PR TITLE
Tighten up .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,5 +24,13 @@
 # Build artifacts
 Default/
 Debug/
+bin/
 *.sln
 *.vcxproj
+Makefile
+haywire.Makefile
+*.mk
+gyp-mac-tool
+
+# Lazily-resolved dependencies
+lib/


### PR DESCRIPTION
There were a lot of artifacts it wasn't ignoring, and you don't actually see them unless you build Haywire.  These are the .mk files, `bin` directory, etc...