### PR TITLE
Include support for adding or setting response headers.

### DIFF
--- a/src/haywire/http_response.c
+++ b/src/haywire/http_response.c
@@ -41,7 +41,7 @@ void hw_set_response_status_code(hw_http_response* response, hw_string* status_c
     resp->status_code = *status_code;
 }
 
-void hw_set_response_header(hw_http_response* response, hw_string* name, hw_string* value)
+void hw_add_response_header(hw_http_response* response, hw_string* name, hw_string* value)
 {
     http_response* resp = (http_response*)response;
     http_header* header = &resp->headers[resp->number_of_headers];
@@ -49,6 +49,24 @@ void hw_set_response_header(hw_http_response* response, hw_string* name, hw_stri
     header->value = *value;
     resp->headers[resp->number_of_headers] = *header;
     resp->number_of_headers++;
+}
+
+void hw_set_response_header(hw_http_response* response, hw_string* name, hw_string* value)
+{
+    http_response* resp = (http_response*)response;
+    int i = 0;
+
+    for (; i < resp->number_of_headers; i++)
+    {
+        http_header* header = &resp->headers[i];
+        if (string_equals(&(header->name), name))
+        {
+            header->value = *value;
+            return;
+        }
+    }
+
+    hw_add_response_header(response, name, value);
 }
 
 void hw_set_body(hw_http_response* response, hw_string* body)

--- a/src/haywire/hw_string.c
+++ b/src/haywire/hw_string.c
@@ -46,3 +46,13 @@ void string_from_int(hw_string* str, int val, int base)
     str->value = &buf[i+1];
     str->length = length;
 }
+
+int string_equals(hw_string* a, hw_string* b)
+{
+    if(a->length != b->length)
+    {
+        return 0;
+    }
+
+    return strncmp(a->value, b->value, a->length) == 0;
+}

--- a/src/haywire/hw_string.h
+++ b/src/haywire/hw_string.h
@@ -4,3 +4,4 @@ hw_string* create_string(const char* value);
 void append_string(hw_string* destination, hw_string* source);
 char* dupstr(const char *s);
 void string_from_int(hw_string* str, int val, int base);
+int string_equals(hw_string* a, hw_string* b);

--- a/src/samples/hello_world/program.c
+++ b/src/samples/hello_world/program.c
@@ -17,22 +17,22 @@ void get_root(http_request* request, hw_http_response* response, void* user_data
     hw_string body;
     hw_string keep_alive_name;
     hw_string keep_alive_value;
-    
+
     SETSTRING(status_code, HTTP_STATUS_200);
     hw_set_response_status_code(response, &status_code);
-    
+
     SETSTRING(content_type_name, "Content-Type");
-    
+
     SETSTRING(content_type_value, "text/html");
     hw_set_response_header(response, &content_type_name, &content_type_value);
-    
+
     SETSTRING(body, "hello world");
     hw_set_body(response, &body);
-    
+
     if (request->keep_alive)
     {
         SETSTRING(keep_alive_name, "Connection");
-        
+
         SETSTRING(keep_alive_value, "Keep-Alive");
         hw_set_response_header(response, &keep_alive_name, &keep_alive_value);
     }
@@ -40,13 +40,86 @@ void get_root(http_request* request, hw_http_response* response, void* user_data
     {
         hw_set_http_version(response, 1, 0);
     }
-    
+
+    hw_http_response_send(response, "user_data", response_complete);
+}
+
+void get_double_headers(http_request* request, hw_http_response* response, void* user_data)
+{
+    hw_string status_code;
+    hw_string content_type_name;
+    hw_string content_type_value;
+    hw_string body;
+    hw_string keep_alive_name;
+    hw_string keep_alive_value;
+
+    SETSTRING(status_code, HTTP_STATUS_200);
+    hw_set_response_status_code(response, &status_code);
+
+    SETSTRING(content_type_name, "Content-Type");
+
+    SETSTRING(content_type_value, "text/html");
+    hw_set_response_header(response, &content_type_name, &content_type_value);
+
+    SETSTRING(body, "hello world");
+    hw_set_body(response, &body);
+
+    if (request->keep_alive)
+    {
+        SETSTRING(keep_alive_name, "Connection");
+
+        SETSTRING(keep_alive_value, "Keep-Alive");
+        hw_add_response_header(response, &keep_alive_name, &keep_alive_value);
+        hw_add_response_header(response, &keep_alive_name, &keep_alive_value);
+    }
+    else
+    {
+        hw_set_http_version(response, 1, 0);
+    }
+
+    hw_http_response_send(response, "user_data", response_complete);
+}
+
+void get_overridden_headers(http_request* request, hw_http_response* response, void* user_data)
+{
+    hw_string status_code;
+    hw_string content_type_name;
+    hw_string content_type_value;
+    hw_string body;
+    hw_string keep_alive_name;
+    hw_string keep_alive_value;
+
+    SETSTRING(status_code, HTTP_STATUS_200);
+    hw_set_response_status_code(response, &status_code);
+
+    SETSTRING(content_type_name, "Content-Type");
+
+    SETSTRING(content_type_value, "text/html");
+    hw_set_response_header(response, &content_type_name, &content_type_value);
+
+    SETSTRING(body, "hello world");
+    hw_set_body(response, &body);
+
+    if (request->keep_alive)
+    {
+        SETSTRING(keep_alive_name, "Connection");
+
+        SETSTRING(keep_alive_value, "Keep-Alive");
+        hw_set_response_header(response, &keep_alive_name, &keep_alive_value);
+
+        SETSTRING(keep_alive_value, "close");
+        hw_set_response_header(response, &keep_alive_name, &keep_alive_value);
+    }
+    else
+    {
+        hw_set_http_version(response, 1, 0);
+    }
+
     hw_http_response_send(response, "user_data", response_complete);
 }
 
 int main(int args, char** argsv)
 {
-    char route[] = "/";
     configuration config;
     config.http_listen_address = "0.0.0.0";
     if (args > 1)
@@ -68,7 +141,10 @@ int main(int args, char** argsv)
     }
     /* hw_init_from_config("hello_world.conf"); */
     hw_init_with_config(&config);
-    hw_http_add_route(route, get_root, NULL);
+    hw_http_add_route("/", get_root, NULL);
+    hw_http_add_route("/double", get_double_headers, NULL);
+    hw_http_add_route("/override", get_overridden_headers, NULL);
+
     hw_http_open();
     return 0;
 }


### PR DESCRIPTION
The crucial bit here is that adding is additive only (i.e. you can double add a header) whereas setting will also add, but if it finds a header with the same name, it will simply update that existing header.

It will only override the first header it finds that matches, though, so if you double add a header, and then try to set the same header, it's only going to update the first.  I don't think that's a corner case worth dealing with, though, unless someone has a good use case to warrant scanning all headers outright.