### PR TITLE
Experimental support for pico HTTP parser

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-sudo: false
+sudo: required
 addons:
   apt:
     packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: c
 sudo: false
+compiler: clang
 script:
   - ./build.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,14 @@
-sudo: required
+sudo: false
 addons:
   apt:
     packages:
     - gcc-4.8
     - g++-4.8
+
+# Use gcc-4.8
+install:
+- if [ "$CXX" = "g++" ]; then export CXX="g++-4.8" CC="gcc-4.8"; fi
+
 compiler: gcc
 language: c
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
 language: c
+sudo: false
 script:
   - ./build.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: c
 sudo: false
-compiler: clang
 script:
   - ./build.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,10 @@
-language: c
 sudo: false
+addons:
+  apt:
+    packages:
+    - gcc-4.8
+    - g++-4.8
+compiler: gcc
+language: c
 script:
   - ./build.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,4 +14,4 @@ install:
 compiler: gcc
 language: c
 script:
-  - ./build.sh
+  - ./make.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ addons:
 
 # Use gcc-4.8
 install:
-- if [ "$CXX" = "g++" ]; then export CXX="g++-4.8" CC="gcc-4.8"; fi
+- export CXX="g++-4.8" CC="gcc-4.8";
 
 compiler: gcc
 language: c

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,15 @@
 sudo: false
-addons:
-  apt:
-    sources:
-    - ubuntu-toolchain-r-test
-    packages:
-    - gcc-4.8
-    - g++-4.8
+#addons:
+#  apt:
+#    sources:
+#    - ubuntu-toolchain-r-test
+#    packages:
+#    - gcc-4.8
+#    - g++-4.8
 
 # Use gcc-4.8
-install:
-- export CXX="g++-4.8" CC="gcc-4.8";
+#install:
+#- export CXX="g++-4.8" CC="gcc-4.8";
 
 compiler: gcc
 language: c

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 sudo: false
 addons:
   apt:
+    sources:
+    - ubuntu-toolchain-r-test
     packages:
     - gcc-4.8
     - g++-4.8

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ set(CMAKE_BUILD_TYPE Debug)
 
 add_definitions(-std=gnu99)
 #add_definitions(-mavx)
-add_definitions(-msse4.2)
+add_definitions(-msse4.1)
 #add_definitions(-std=c++11)
 add_definitions(-Weffc++)
 add_definitions(-pedantic)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,16 +5,14 @@ include("common.cmake")
 # Haywire
 # ----------------------------------------
 project(haywire C)
-#set(CMAKE_BUILD_TYPE RelWithDebInfo)
-set(CMAKE_BUILD_TYPE Debug)
+set(CMAKE_BUILD_TYPE RelWithDebInfo)
+#set(CMAKE_BUILD_TYPE Debug)
 
 add_definitions(-std=gnu99)
 #add_definitions(-mavx)
 add_definitions(-msse4.1)
-#add_definitions(-std=c++11)
-add_definitions(-Weffc++)
 add_definitions(-pedantic)
-#add_definitions(-O3)
+add_definitions(-O3)
 add_definitions(-Wall)
 add_definitions(-Wextra)
 add_definitions(-Wcast-align)
@@ -64,9 +62,6 @@ add_dependencies(hello_world haywire)
 # Libraries to link in reverse order because that's what ld requires.
 target_link_libraries (hello_world
     ${haywire_location}
-    ${CMAKE_THREAD_LIBS_INIT})
-
-target_link_libraries(hello_world
     ${CMAKE_SOURCE_DIR}/lib/libuv/.libs/libuv.a
+    rt
     ${CMAKE_THREAD_LIBS_INIT})
-

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,6 +65,6 @@ target_link_libraries (hello_world
     ${CMAKE_SOURCE_DIR}/lib/libuv/.libs/libuv.a
     ${CMAKE_THREAD_LIBS_INIT})
 
-if (LINUX)
+if (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
     target_link_libraries (hello_world rt)
-endif()
+endif (${CMAKE_SYSTEM_NAME} MATCHES "Linux")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,5 +63,8 @@ add_dependencies(hello_world haywire)
 target_link_libraries (hello_world
     ${haywire_location}
     ${CMAKE_SOURCE_DIR}/lib/libuv/.libs/libuv.a
-    rt
     ${CMAKE_THREAD_LIBS_INIT})
+
+if (LINUX)
+    target_link_libraries (hello_world rt)
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,7 @@ project(haywire C)
 #set(CMAKE_BUILD_TYPE RelWithDebInfo)
 set(CMAKE_BUILD_TYPE Debug)
 
+add_definitions(-std=gnu99)
 #add_definitions(-mavx)
 add_definitions(-msse4.2)
 #add_definitions(-std=c++11)

--- a/compile_dependencies.sh
+++ b/compile_dependencies.sh
@@ -1,15 +1,4 @@
 #!/bin/bash
-# Getting libuv
-if [ ! -d "lib/libuv" ]; then
-    echo "git clone https://github.com/libuv/libuv.git lib/libuv"
-    git clone https://github.com/libuv/libuv.git lib/libuv
-    cd lib/libuv
-    sh autogen.sh
-    ./configure
-    make
-fi
-
-#!/bin/bash
 
 # Getting libuv
 if [ ! -d "lib/libuv" ]; then

--- a/include/haywire.h
+++ b/include/haywire.h
@@ -147,6 +147,7 @@ typedef struct
     int http_listen_port;
     int thread_count;
     char* parser;
+    int response_batch_size;
 } configuration;
 
 typedef struct

--- a/src/haywire/connection_consumer.c
+++ b/src/haywire/connection_consumer.c
@@ -61,7 +61,8 @@ void connection_consumer_new_connection(uv_stream_t* server_handle, int status)
     
     connection->parser.data = connection;
     connection->stream.data = connection;
-    
+    connection->response_buffers_count = 0;
+
     rc = uv_tcp_init(server_handle->loop, &connection->stream);
     rc = uv_accept(server_handle, (uv_stream_t*)&connection->stream);
     rc = uv_read_start((uv_stream_t*)&connection->stream, http_stream_on_alloc, http_stream_on_read);

--- a/src/haywire/http.h
+++ b/src/haywire/http.h
@@ -1,0 +1,34 @@
+#pragma once
+#include "uv.h"
+#include "http_parser.h"
+#include "http_request.h"
+
+typedef struct http_connection
+{
+    uv_tcp_t stream;
+    http_parser parser;
+    uv_write_t write_req;
+    http_request* request;
+    char current_header_key[1024];
+    int current_header_key_length;
+    char current_header_value[1024];
+    int current_header_value_length;
+    int keep_alive;
+    int last_was_value;
+    uv_buf_t response_buffers[1024];
+    int response_buffers_count;
+    int prevbuflen;
+    char request_buffer[4000096];
+    int request_buffer_length;
+} http_connection;
+
+http_request* create_http_request(http_connection* connection);
+void free_http_request(http_request* request);
+int http_request_on_message_begin(http_parser *parser);
+int http_request_on_url(http_parser *parser, const char *at, size_t length);
+int http_request_on_header_field(http_parser *parser, const char *at, size_t length);
+int http_request_on_header_value(http_parser *parser, const char *at, size_t length);
+int http_request_on_body(http_parser *parser, const char *at, size_t length);
+int http_request_on_headers_complete(http_parser *parser);
+int http_request_on_message_complete(http_parser *parser);
+int http_request_complete_request(struct http_connection* connection);

--- a/src/haywire/http_connection.h
+++ b/src/haywire/http_connection.h
@@ -17,4 +17,7 @@ typedef struct
     int last_was_value;
     uv_buf_t response_buffers[1024];
     int response_buffers_count;
+    int prevbuflen;
+    char request_buffer[4000096];
+    int request_buffer_length;
 } http_connection;

--- a/src/haywire/http_connection.h
+++ b/src/haywire/http_connection.h
@@ -15,4 +15,6 @@ typedef struct
     int current_header_value_length;
     int keep_alive;
     int last_was_value;
+    uv_buf_t response_buffers[1024];
+    int response_buffers_count;
 } http_connection;

--- a/src/haywire/http_connection.h
+++ b/src/haywire/http_connection.h
@@ -1,23 +1,2 @@
 #pragma once
-#include "uv.h"
-#include "http_parser.h"
-#include "http_request.h"
-
-typedef struct
-{
-    uv_tcp_t stream;
-    http_parser parser;
-    uv_write_t write_req;
-    http_request* request;
-    char current_header_key[1024];
-    int current_header_key_length;
-    char current_header_value[1024];
-    int current_header_value_length;
-    int keep_alive;
-    int last_was_value;
-    uv_buf_t response_buffers[1024];
-    int response_buffers_count;
-    int prevbuflen;
-    char request_buffer[4000096];
-    int request_buffer_length;
-} http_connection;
+#include "http.h"

--- a/src/haywire/http_request.c
+++ b/src/haywire/http_request.c
@@ -5,6 +5,7 @@
 #include "haywire.h"
 #include "hw_string.h"
 #include "khash.h"
+#include "http.h"
 #include "http_request.h"
 #include "http_response.h"
 #include "http_parser.h"
@@ -84,7 +85,7 @@ void free_http_request(http_request* request)
         free((char*)v);
     });
     kh_destroy(string_hashmap, request->headers);
-    free(request->url);
+    //free(request->url);
     if (request->body->length > 0)
     {
         free(request->body->value);
@@ -260,6 +261,11 @@ void get_404_response(http_request* request, http_response* response)
 int http_request_on_message_complete(http_parser* parser)
 {
     http_connection* connection = (http_connection*)parser->data;
+    return http_request_complete_request(connection);
+}
+
+int http_request_complete_request(struct http_connection* connection)
+{
     hw_route_entry* route_entry = get_route_callback(connection->request->url);
     hw_string* response_buffer;
     hw_write_context* write_context;

--- a/src/haywire/http_request.h
+++ b/src/haywire/http_request.h
@@ -1,14 +1,6 @@
 #pragma once
 #include "uv.h"
 #include "http_parser.h"
+#include "http_connection.h"
 
 extern int last_was_value;
-
-void free_http_request(http_request* request);
-int http_request_on_message_begin(http_parser *parser);
-int http_request_on_url(http_parser *parser, const char *at, size_t length);
-int http_request_on_header_field(http_parser *parser, const char *at, size_t length);
-int http_request_on_header_value(http_parser *parser, const char *at, size_t length);
-int http_request_on_body(http_parser *parser, const char *at, size_t length);
-int http_request_on_headers_complete(http_parser *parser);
-int http_request_on_message_complete(http_parser *parser);

--- a/src/haywire/http_server.h
+++ b/src/haywire/http_server.h
@@ -41,5 +41,6 @@ void http_stream_on_connect(uv_stream_t* stream, int status);
 void http_stream_on_alloc(uv_handle_t* client, size_t suggested_size, uv_buf_t* buf);
 void http_stream_on_close(uv_handle_t* handle);
 int http_server_write_response_single(hw_write_context* write_context, hw_string* response);
+int http_server_write_response_batched(hw_write_context* write_context, hw_string* response);
 void http_server_after_write(uv_write_t* req, int status);
 void http_stream_on_read_http_parser(uv_stream_t* tcp, ssize_t nread, const uv_buf_t* buf);

--- a/src/haywire/http_server.h
+++ b/src/haywire/http_server.h
@@ -44,3 +44,4 @@ int http_server_write_response_single(hw_write_context* write_context, hw_string
 int http_server_write_response_batched(hw_write_context* write_context, hw_string* response);
 void http_server_after_write(uv_write_t* req, int status);
 void http_stream_on_read_http_parser(uv_stream_t* tcp, ssize_t nread, const uv_buf_t* buf);
+void http_stream_on_read_pico(uv_stream_t* tcp, ssize_t nread, const uv_buf_t* buf);

--- a/src/haywire/picohttpparser.c
+++ b/src/haywire/picohttpparser.c
@@ -1,0 +1,596 @@
+/*
+ * Copyright (c) 2009-2014 Kazuho Oku, Tokuhiro Matsuno, Daisuke Murase,
+ *                         Shigeo Mitsunari
+ *
+ * The software is licensed under either the MIT License (below) or the Perl
+ * license.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+#include <assert.h>
+#include <stddef.h>
+#include <string.h>
+#ifdef __SSE4_2__
+#ifdef _MSC_VER
+#include <nmmintrin.h>
+#else
+#include <x86intrin.h>
+#endif
+#endif
+#include "picohttpparser.h"
+
+/* $Id$ */
+
+#if __GNUC__ >= 3
+#define likely(x) __builtin_expect(!!(x), 1)
+#define unlikely(x) __builtin_expect(!!(x), 0)
+#else
+#define likely(x) (x)
+#define unlikely(x) (x)
+#endif
+
+#ifdef _MSC_VER
+#define ALIGNED(n) _declspec(align(n))
+#else
+#define ALIGNED(n) __attribute__((aligned(n)))
+#endif
+
+#define IS_PRINTABLE_ASCII(c) ((unsigned char)(c)-040u < 0137u)
+
+#define CHECK_EOF()                                                                                                                \
+    if (buf == buf_end) {                                                                                                          \
+        *ret = -2;                                                                                                                 \
+        return NULL;                                                                                                               \
+    }
+
+#define EXPECT_CHAR(ch)                                                                                                            \
+    CHECK_EOF();                                                                                                                   \
+    if (*buf++ != ch) {                                                                                                            \
+        *ret = -1;                                                                                                                 \
+        return NULL;                                                                                                               \
+    }
+
+#define ADVANCE_TOKEN(tok, toklen)                                                                                                 \
+    do {                                                                                                                           \
+        const char *tok_start = buf;                                                                                               \
+        static const char ALIGNED(16) ranges2[] = "\000\040\177\177";                                                              \
+        int found2;                                                                                                                \
+        buf = findchar_fast(buf, buf_end, ranges2, sizeof(ranges2) - 1, &found2);                                                  \
+        if (!found2) {                                                                                                             \
+            CHECK_EOF();                                                                                                           \
+        }                                                                                                                          \
+        while (1) {                                                                                                                \
+            if (*buf == ' ') {                                                                                                     \
+                break;                                                                                                             \
+            } else if (unlikely(!IS_PRINTABLE_ASCII(*buf))) {                                                                      \
+                if ((unsigned char)*buf < '\040' || *buf == '\177') {                                                              \
+                    *ret = -1;                                                                                                     \
+                    return NULL;                                                                                                   \
+                }                                                                                                                  \
+            }                                                                                                                      \
+            ++buf;                                                                                                                 \
+            CHECK_EOF();                                                                                                           \
+        }                                                                                                                          \
+        tok = tok_start;                                                                                                           \
+        toklen = buf - tok_start;                                                                                                  \
+    } while (0)
+
+static const char *token_char_map = "\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0"
+                                    "\0\1\1\1\1\1\1\1\0\0\1\1\0\1\1\0\1\1\1\1\1\1\1\1\1\1\0\0\0\0\0\0"
+                                    "\0\1\1\1\1\1\1\1\1\1\1\1\1\1\1\1\1\1\1\1\1\1\1\1\1\1\1\0\0\0\1\1"
+                                    "\1\1\1\1\1\1\1\1\1\1\1\1\1\1\1\1\1\1\1\1\1\1\1\1\1\1\1\0\1\0\1\0"
+                                    "\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0"
+                                    "\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0"
+                                    "\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0"
+                                    "\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0";
+
+static const char *findchar_fast(const char *buf, const char *buf_end, const char *ranges, size_t ranges_size, int *found)
+{
+    *found = 0;
+#if __SSE4_2__
+    if (likely(buf_end - buf >= 16)) {
+        __m128i ranges16 = _mm_loadu_si128((const __m128i *)ranges);
+
+        size_t left = (buf_end - buf) & ~15;
+        do {
+            __m128i b16 = _mm_loadu_si128((void *)buf);
+            int r = _mm_cmpestri(ranges16, ranges_size, b16, 16, _SIDD_LEAST_SIGNIFICANT | _SIDD_CMP_RANGES | _SIDD_UBYTE_OPS);
+            if (unlikely(r != 16)) {
+                buf += r;
+                *found = 1;
+                break;
+            }
+            buf += 16;
+            left -= 16;
+        } while (likely(left != 0));
+    }
+#endif
+    return buf;
+}
+
+static const char *get_token_to_eol(const char *buf, const char *buf_end, const char **token, size_t *token_len, int *ret)
+{
+    const char *token_start = buf;
+
+#ifdef __SSE4_2__
+    static const char ranges1[] = "\0\010"
+                                  /* allow HT */
+                                  "\012\037"
+                                  /* allow SP and up to but not including DEL */
+                                  "\177\177"
+        /* allow chars w. MSB set */
+        ;
+    int found;
+    buf = findchar_fast(buf, buf_end, ranges1, sizeof(ranges1) - 1, &found);
+    if (found)
+        goto FOUND_CTL;
+#else
+    /* find non-printable char within the next 8 bytes, this is the hottest code; manually inlined */
+    while (likely(buf_end - buf >= 8)) {
+#define DOIT()                                                                                                                     \
+    do {                                                                                                                           \
+        if (unlikely(!IS_PRINTABLE_ASCII(*buf)))                                                                                   \
+            goto NonPrintable;                                                                                                     \
+        ++buf;                                                                                                                     \
+    } while (0)
+        DOIT();
+        DOIT();
+        DOIT();
+        DOIT();
+        DOIT();
+        DOIT();
+        DOIT();
+        DOIT();
+#undef DOIT
+        continue;
+    NonPrintable:
+        if ((likely((unsigned char)*buf < '\040') && likely(*buf != '\011')) || unlikely(*buf == '\177')) {
+            goto FOUND_CTL;
+        }
+        ++buf;
+    }
+#endif
+    for (;; ++buf) {
+        CHECK_EOF();
+        if (unlikely(!IS_PRINTABLE_ASCII(*buf))) {
+            if ((likely((unsigned char)*buf < '\040') && likely(*buf != '\011')) || unlikely(*buf == '\177')) {
+                goto FOUND_CTL;
+            }
+        }
+    }
+FOUND_CTL:
+    if (likely(*buf == '\015')) {
+        ++buf;
+        EXPECT_CHAR('\012');
+        *token_len = buf - 2 - token_start;
+    } else if (*buf == '\012') {
+        *token_len = buf - token_start;
+        ++buf;
+    } else {
+        *ret = -1;
+        return NULL;
+    }
+    *token = token_start;
+
+    return buf;
+}
+
+static const char *is_complete(const char *buf, const char *buf_end, size_t last_len, int *ret)
+{
+    int ret_cnt = 0;
+    buf = last_len < 3 ? buf : buf + last_len - 3;
+
+    while (1) {
+        CHECK_EOF();
+        if (*buf == '\015') {
+            ++buf;
+            CHECK_EOF();
+            EXPECT_CHAR('\012');
+            ++ret_cnt;
+        } else if (*buf == '\012') {
+            ++buf;
+            ++ret_cnt;
+        } else {
+            ++buf;
+            ret_cnt = 0;
+        }
+        if (ret_cnt == 2) {
+            return buf;
+        }
+    }
+
+    *ret = -2;
+    return NULL;
+}
+
+/* *_buf is always within [buf, buf_end) upon success */
+static const char *parse_int(const char *buf, const char *buf_end, int *value, int *ret)
+{
+    int v;
+    CHECK_EOF();
+    if (!('0' <= *buf && *buf <= '9')) {
+        *ret = -1;
+        return NULL;
+    }
+    v = 0;
+    for (;; ++buf) {
+        CHECK_EOF();
+        if ('0' <= *buf && *buf <= '9') {
+            v = v * 10 + *buf - '0';
+        } else {
+            break;
+        }
+    }
+
+    *value = v;
+    return buf;
+}
+
+/* returned pointer is always within [buf, buf_end), or null */
+static const char *parse_http_version(const char *buf, const char *buf_end, int *minor_version, int *ret)
+{
+    EXPECT_CHAR('H');
+    EXPECT_CHAR('T');
+    EXPECT_CHAR('T');
+    EXPECT_CHAR('P');
+    EXPECT_CHAR('/');
+    EXPECT_CHAR('1');
+    EXPECT_CHAR('.');
+    return parse_int(buf, buf_end, minor_version, ret);
+}
+
+static const char *parse_headers(const char *buf, const char *buf_end, struct phr_header *headers, size_t *num_headers,
+                                 size_t max_headers, int *ret)
+{
+    for (;; ++*num_headers) {
+        CHECK_EOF();
+        if (*buf == '\015') {
+            ++buf;
+            EXPECT_CHAR('\012');
+            break;
+        } else if (*buf == '\012') {
+            ++buf;
+            break;
+        }
+        if (*num_headers == max_headers) {
+            *ret = -1;
+            return NULL;
+        }
+        if (!(*num_headers != 0 && (*buf == ' ' || *buf == '\t'))) {
+            if (!token_char_map[(unsigned char)*buf]) {
+                *ret = -1;
+                return NULL;
+            }
+            /* parsing name, but do not discard SP before colon, see
+             * http://www.mozilla.org/security/announce/2006/mfsa2006-33.html */
+            headers[*num_headers].name = buf;
+            static const char ALIGNED(16) ranges1[] = "::\x00\037";
+            int found;
+            buf = findchar_fast(buf, buf_end, ranges1, sizeof(ranges1) - 1, &found);
+            if (!found) {
+                CHECK_EOF();
+            }
+            while (1) {
+                if (*buf == ':') {
+                    break;
+                } else if (*buf < ' ') {
+                    *ret = -1;
+                    return NULL;
+                }
+                ++buf;
+                CHECK_EOF();
+            }
+            headers[*num_headers].name_len = buf - headers[*num_headers].name;
+            ++buf;
+            for (;; ++buf) {
+                CHECK_EOF();
+                if (!(*buf == ' ' || *buf == '\t')) {
+                    break;
+                }
+            }
+        } else {
+            headers[*num_headers].name = NULL;
+            headers[*num_headers].name_len = 0;
+        }
+        if ((buf = get_token_to_eol(buf, buf_end, &headers[*num_headers].value, &headers[*num_headers].value_len, ret)) == NULL) {
+            return NULL;
+        }
+    }
+    return buf;
+}
+
+static const char *parse_request(const char *buf, const char *buf_end, const char **method, size_t *method_len, const char **path,
+                                 size_t *path_len, int *minor_version, struct phr_header *headers, size_t *num_headers,
+                                 size_t max_headers, int *ret)
+{
+    /* skip first empty line (some clients add CRLF after POST content) */
+    CHECK_EOF();
+    if (*buf == '\015') {
+        ++buf;
+        EXPECT_CHAR('\012');
+    } else if (*buf == '\012') {
+        ++buf;
+    }
+
+    /* parse request line */
+    ADVANCE_TOKEN(*method, *method_len);
+    ++buf;
+    ADVANCE_TOKEN(*path, *path_len);
+    ++buf;
+    if ((buf = parse_http_version(buf, buf_end, minor_version, ret)) == NULL) {
+        return NULL;
+    }
+    if (*buf == '\015') {
+        ++buf;
+        EXPECT_CHAR('\012');
+    } else if (*buf == '\012') {
+        ++buf;
+    } else {
+        *ret = -1;
+        return NULL;
+    }
+
+    return parse_headers(buf, buf_end, headers, num_headers, max_headers, ret);
+}
+
+int phr_parse_request(const char *buf_start, size_t len, const char **method, size_t *method_len, const char **path,
+                      size_t *path_len, int *minor_version, struct phr_header *headers, size_t *num_headers, size_t last_len)
+{
+    const char *buf = buf_start, *buf_end = buf_start + len;
+    size_t max_headers = *num_headers;
+    int r;
+
+    *method = NULL;
+    *method_len = 0;
+    *path = NULL;
+    *path_len = 0;
+    *minor_version = -1;
+    *num_headers = 0;
+
+    /* if last_len != 0, check if the request is complete (a fast countermeasure
+       againt slowloris */
+    if (last_len != 0 && is_complete(buf, buf_end, last_len, &r) == NULL) {
+        return r;
+    }
+
+    if ((buf = parse_request(buf, buf_end, method, method_len, path, path_len, minor_version, headers, num_headers, max_headers,
+                             &r)) == NULL) {
+        return r;
+    }
+
+    return (int)(buf - buf_start);
+}
+
+static const char *parse_response(const char *buf, const char *buf_end, int *minor_version, int *status, const char **msg,
+                                  size_t *msg_len, struct phr_header *headers, size_t *num_headers, size_t max_headers, int *ret)
+{
+    /* parse "HTTP/1.x" */
+    if ((buf = parse_http_version(buf, buf_end, minor_version, ret)) == NULL) {
+        return NULL;
+    }
+    /* skip space */
+    if (*buf++ != ' ') {
+        *ret = -1;
+        return NULL;
+    }
+    /* parse status code */
+    if ((buf = parse_int(buf, buf_end, status, ret)) == NULL) {
+        return NULL;
+    }
+    /* skip space */
+    if (*buf++ != ' ') {
+        *ret = -1;
+        return NULL;
+    }
+    /* get message */
+    if ((buf = get_token_to_eol(buf, buf_end, msg, msg_len, ret)) == NULL) {
+        return NULL;
+    }
+
+    return parse_headers(buf, buf_end, headers, num_headers, max_headers, ret);
+}
+
+int phr_parse_response(const char *buf_start, size_t len, int *minor_version, int *status, const char **msg, size_t *msg_len,
+                       struct phr_header *headers, size_t *num_headers, size_t last_len)
+{
+    const char *buf = buf_start, *buf_end = buf + len;
+    size_t max_headers = *num_headers;
+    int r;
+
+    *minor_version = -1;
+    *status = 0;
+    *msg = NULL;
+    *msg_len = 0;
+    *num_headers = 0;
+
+    /* if last_len != 0, check if the response is complete (a fast countermeasure
+       against slowloris */
+    if (last_len != 0 && is_complete(buf, buf_end, last_len, &r) == NULL) {
+        return r;
+    }
+
+    if ((buf = parse_response(buf, buf_end, minor_version, status, msg, msg_len, headers, num_headers, max_headers, &r)) == NULL) {
+        return r;
+    }
+
+    return (int)(buf - buf_start);
+}
+
+int phr_parse_headers(const char *buf_start, size_t len, struct phr_header *headers, size_t *num_headers, size_t last_len)
+{
+    const char *buf = buf_start, *buf_end = buf + len;
+    size_t max_headers = *num_headers;
+    int r;
+
+    *num_headers = 0;
+
+    /* if last_len != 0, check if the response is complete (a fast countermeasure
+       against slowloris */
+    if (last_len != 0 && is_complete(buf, buf_end, last_len, &r) == NULL) {
+        return r;
+    }
+
+    if ((buf = parse_headers(buf, buf_end, headers, num_headers, max_headers, &r)) == NULL) {
+        return r;
+    }
+
+    return (int)(buf - buf_start);
+}
+
+enum {
+    CHUNKED_IN_CHUNK_SIZE,
+    CHUNKED_IN_CHUNK_EXT,
+    CHUNKED_IN_CHUNK_DATA,
+    CHUNKED_IN_CHUNK_CRLF,
+    CHUNKED_IN_TRAILERS_LINE_HEAD,
+    CHUNKED_IN_TRAILERS_LINE_MIDDLE
+};
+
+static int decode_hex(int ch)
+{
+    if ('0' <= ch && ch <= '9') {
+        return ch - '0';
+    } else if ('A' <= ch && ch <= 'F') {
+        return ch - 'A' + 0xa;
+    } else if ('a' <= ch && ch <= 'f') {
+        return ch - 'a' + 0xa;
+    } else {
+        return -1;
+    }
+}
+
+ssize_t phr_decode_chunked(struct phr_chunked_decoder *decoder, char *buf, size_t *_bufsz)
+{
+    size_t dst = 0, src = 0, bufsz = *_bufsz;
+    ssize_t ret = -2; /* incomplete */
+
+    while (1) {
+        switch (decoder->_state) {
+        case CHUNKED_IN_CHUNK_SIZE:
+            for (;; ++src) {
+                int v;
+                if (src == bufsz)
+                    goto Exit;
+                if ((v = decode_hex(buf[src])) == -1) {
+                    if (decoder->_hex_count == 0) {
+                        ret = -1;
+                        goto Exit;
+                    }
+                    break;
+                }
+                if (decoder->_hex_count == sizeof(size_t) * 2) {
+                    ret = -1;
+                    goto Exit;
+                }
+                decoder->bytes_left_in_chunk = decoder->bytes_left_in_chunk * 16 + v;
+                ++decoder->_hex_count;
+            }
+            decoder->_hex_count = 0;
+            decoder->_state = CHUNKED_IN_CHUNK_EXT;
+        /* fallthru */
+        case CHUNKED_IN_CHUNK_EXT:
+            /* RFC 7230 A.2 "Line folding in chunk extensions is disallowed" */
+            for (;; ++src) {
+                if (src == bufsz)
+                    goto Exit;
+                if (buf[src] == '\012')
+                    break;
+            }
+            ++src;
+            if (decoder->bytes_left_in_chunk == 0) {
+                if (decoder->consume_trailer) {
+                    decoder->_state = CHUNKED_IN_TRAILERS_LINE_HEAD;
+                    break;
+                } else {
+                    goto Complete;
+                }
+            }
+            decoder->_state = CHUNKED_IN_CHUNK_DATA;
+        /* fallthru */
+        case CHUNKED_IN_CHUNK_DATA: {
+            size_t avail = bufsz - src;
+            if (avail < decoder->bytes_left_in_chunk) {
+                if (dst != src)
+                    memmove(buf + dst, buf + src, avail);
+                src += avail;
+                dst += avail;
+                decoder->bytes_left_in_chunk -= avail;
+                goto Exit;
+            }
+            if (dst != src)
+                memmove(buf + dst, buf + src, decoder->bytes_left_in_chunk);
+            src += decoder->bytes_left_in_chunk;
+            dst += decoder->bytes_left_in_chunk;
+            decoder->bytes_left_in_chunk = 0;
+            decoder->_state = CHUNKED_IN_CHUNK_CRLF;
+        }
+        /* fallthru */
+        case CHUNKED_IN_CHUNK_CRLF:
+            for (;; ++src) {
+                if (src == bufsz)
+                    goto Exit;
+                if (buf[src] != '\015')
+                    break;
+            }
+            if (buf[src] != '\012') {
+                ret = -1;
+                goto Exit;
+            }
+            ++src;
+            decoder->_state = CHUNKED_IN_CHUNK_SIZE;
+            break;
+        case CHUNKED_IN_TRAILERS_LINE_HEAD:
+            for (;; ++src) {
+                if (src == bufsz)
+                    goto Exit;
+                if (buf[src] != '\015')
+                    break;
+            }
+            if (buf[src++] == '\012')
+                goto Complete;
+            decoder->_state = CHUNKED_IN_TRAILERS_LINE_MIDDLE;
+        /* fallthru */
+        case CHUNKED_IN_TRAILERS_LINE_MIDDLE:
+            for (;; ++src) {
+                if (src == bufsz)
+                    goto Exit;
+                if (buf[src] == '\012')
+                    break;
+            }
+            ++src;
+            decoder->_state = CHUNKED_IN_TRAILERS_LINE_HEAD;
+            break;
+        default:
+            assert(!"decoder is corrupt");
+        }
+    }
+
+Complete:
+    ret = bufsz - src;
+Exit:
+    if (dst != src)
+        memmove(buf + dst, buf + src, bufsz - src);
+    *_bufsz = dst;
+    return ret;
+}
+
+#undef CHECK_EOF
+#undef EXPECT_CHAR
+#undef ADVANCE_TOKEN

--- a/src/haywire/picohttpparser.h
+++ b/src/haywire/picohttpparser.h
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2009-2014 Kazuho Oku, Tokuhiro Matsuno, Daisuke Murase,
+ *                         Shigeo Mitsunari
+ *
+ * The software is licensed under either the MIT License (below) or the Perl
+ * license.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+#ifndef picohttpparser_h
+#define picohttpparser_h
+
+#include <sys/types.h>
+
+#ifdef _MSC_VER
+#define ssize_t intptr_t
+#endif
+
+/* $Id$ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* contains name and value of a header (name == NULL if is a continuing line
+ * of a multiline header */
+struct phr_header {
+    const char *name;
+    size_t name_len;
+    const char *value;
+    size_t value_len;
+};
+
+/* returns number of bytes consumed if successful, -2 if request is partial,
+ * -1 if failed */
+int phr_parse_request(const char *buf, size_t len, const char **method, size_t *method_len, const char **path, size_t *path_len,
+                      int *minor_version, struct phr_header *headers, size_t *num_headers, size_t last_len);
+
+/* ditto */
+int phr_parse_response(const char *_buf, size_t len, int *minor_version, int *status, const char **msg, size_t *msg_len,
+                       struct phr_header *headers, size_t *num_headers, size_t last_len);
+
+/* ditto */
+int phr_parse_headers(const char *buf, size_t len, struct phr_header *headers, size_t *num_headers, size_t last_len);
+
+/* should be zero-filled before start */
+struct phr_chunked_decoder {
+    size_t bytes_left_in_chunk; /* number of bytes left in current chunk */
+    char consume_trailer;       /* if trailing headers should be consumed */
+    char _hex_count;
+    char _state;
+};
+
+/* the function rewrites the buffer given as (buf, bufsz) removing the chunked-
+ * encoding headers.  When the function returns without an error, bufsz is
+ * updated to the length of the decoded data available.  Applications should
+ * repeatedly call the function while it returns -2 (incomplete) every time
+ * supplying newly arrived data.  If the end of the chunked-encoded data is
+ * found, the function returns a non-negative number indicating the number of
+ * octets left undecoded at the tail of the supplied buffer.  Returns -1 on
+ * error.
+ */
+ssize_t phr_decode_chunked(struct phr_chunked_decoder *decoder, char *buf, size_t *bufsz);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/samples/hello_world/program.c
+++ b/src/samples/hello_world/program.c
@@ -60,6 +60,7 @@ int main(int args, char** argsv)
     opt_flag_int(conf, &config.response_batch_size, "batch", 0, "Size to batch before sending responses.");
     args = opt_config_parse(conf, args, argsv);
 
+    //hw_init_from_config("hello_world.conf");
     hw_init_with_config(&config);
     hw_http_add_route(route, get_root, NULL);
     hw_http_open();

--- a/src/samples/hello_world/program.c
+++ b/src/samples/hello_world/program.c
@@ -60,7 +60,6 @@ int main(int args, char** argsv)
     opt_flag_int(conf, &config.response_batch_size, "batch", 0, "Size to batch before sending responses.");
     args = opt_config_parse(conf, args, argsv);
 
-    //hw_init_from_config("hello_world.conf");
     hw_init_with_config(&config);
     hw_http_add_route(route, get_root, NULL);
     hw_http_open();

--- a/src/samples/hello_world/program.c
+++ b/src/samples/hello_world/program.c
@@ -57,6 +57,7 @@ int main(int args, char** argsv)
     opt_flag_int(conf, &config.http_listen_port, "port", 8000, "Port to listen on.");
     opt_flag_int(conf, &config.thread_count, "threads", 0, "Number of threads to use.");
     opt_flag_string(conf, &config.parser, "parser", "http_parser", "HTTP parser to use");
+    opt_flag_int(conf, &config.response_batch_size, "batch", 0, "Size to batch before sending responses.");
     args = opt_config_parse(conf, args, argsv);
 
     //hw_init_from_config("hello_world.conf");


### PR DESCRIPTION
@nmdguerreiro I would love your code review feedback on this because there's some flaws in my implementation.

`pico` http parser is a SSE accelerated HTTP parser. This can gain us quite a lot of performance in Haywire I believe. It's not a streaming parser like `http_parser` that Haywire already uses but I've made it so you can configure which one Haywire uses. There's a cloudflare fork of this parser that is AVX optimized as well. I don't want to require AVX or SSE but since performance is Haywire's main goal, I want to get these integrated and see how fast we can go!

Keep in mind there's some hard coded values and not tidy stuff in this branch so far because I'm experimenting. There's a major bug in my implementation though which is killing performance that I would love a code review on to get it fixed so we can see the potential of `pico` in Haywire.

To run `pico` run the following `./build/hello_world --parser pico`

The big problem with my pico implementation is it's losing requests over time. The longer the benchmark the slower the requests/second throughput rate is. If you run `dstat` and watch network throughput you'll see over time it slows down until almost no responses get sent. I suspect that there's a loop/buffer management issue that is causing requests to stall and never get processed.

If you do a really short benchmark you can see some amazing potential.

### HTTP_PARSER
```
./build/hello_world --threads 20 --parser http_parser --batch 64

../bin/wrk/wrk --script ./pipelined_get.lua --latency -d 10s -t 20 -c 256 http://104.130.19.205:8000 -- 64
Running 10s test @ http://104.130.19.205:8000
  20 threads and 256 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency    11.77ms   12.04ms  63.20ms   75.96%
    Req/Sec   147.27k    49.42k  348.40k    75.32%
  Latency Distribution
     50%    6.78ms
     75%   23.08ms
     90%   34.49ms
     99%    0.00us
  29456134 requests in 10.10s, 4.33GB read
Requests/sec: 2,916,682.82
Transfer/sec:    439.49MB
```

### PICO
2 second run shows some great potential.

```
./build/hello_world --threads 20 --parser pico --batch 64

./bin/wrk/wrk --script ./pipelined_get.lua --latency -d 2s -t 20 -c 256 http://104.130.19.205:8000 -- 64
Running 2s test @ http://104.130.19.205:8000
  20 threads and 256 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   661.65us  488.02us   9.51ms   71.29%
    Req/Sec   386.06k    88.75k  486.79k    41.35%
  Latency Distribution
     50%  740.00us
     75%    1.27ms
     90%    0.00us
     99%    0.00us
  15980992 requests in 2.10s, 2.35GB read
Requests/sec: 7,610,895.00
Transfer/sec:      1.12GB
```

2 minute run shows how performance tanked over time.
```
./build/hello_world --threads 20 --parser pico --batch 64

../bin/wrk/wrk --script ./pipelined_get.lua --latency -d 2m -t 20 -c 256 http://104.130.19.205:8000 -- 64
Running 2m test @ http://104.130.19.205:8000
  20 threads and 256 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   401.47us  341.74us  16.19ms   88.10%
    Req/Sec   233.44k    71.54k  561.32k    73.52%
  Latency Distribution
     50%  262.00us
     75%  448.00us
     90%  812.00us
     99%    1.77ms
  141840704 requests in 2.00m, 20.87GB read
Requests/sec: 1,181,341.04
Transfer/sec:    178.01MB
```

dstat output during the pico run
```
dstat -n --output output.csv

-net/total-
 recv  send
5870B  274B
 120M  415M
 332M 1145M
 254M  877M
 210M  724M
 180M  622M
 150M  519M
 142M  489M
 127M  438M
 100M  343M
  90M  312M
  80M  277M
  77M  265M
  77M  266M
  77M  266M
  77M  266M
  76M  262M
  76M  263M
  79M  272M
  77M  265M
  71M  244M
  70M  242M
  70M  242M
  64M  221M
  60M  207M
  55M  191M
  52M  180M
  52M  181M
  52M  180M
  52M  180M
  52M  180M
-net/total-
 recv  send
  52M  180M
  52M  180M
  52M  180M
  52M  180M
  52M  180M
  52M  180M
  51M  175M
  52M  178M
  52M  180M
  52M  179M
  52M  180M
  52M  179M
  52M  180M
  52M  180M
  52M  180M
  52M  179M
  50M  174M
  50M  172M
  50M  172M
  50M  172M
  50M  172M
  50M  172M
  50M  172M
  50M  172M
  50M  173M
  50M  171M
  51M  175M
  51M  176M
  51M  176M
  51M  176M
  51M  176M
  51M  176M
  51M  176M
  51M  176M
  51M  176M
  47M  161M
  47M  164M
  48M  165M
  48M  166M
-net/total-
 recv  send
  48M  167M
  48M  166M
  48M  166M
  48M  166M
  48M  167M
  48M  167M
  48M  165M
  47M  164M
  47M  164M
  48M  165M
  48M  164M
  49M  168M
  48M  165M
  47M  163M
  48M  165M
  40M  139M
  30M  103M
  30M  103M
  30M  103M
  30M  102M
  30M  102M
  30M  102M
  30M  102M
  30M  102M
  30M  102M
  30M  102M
  29M  102M
  29M  102M
  29M  102M
  29M  102M
  30M  102M
  30M  102M
  30M  102M
  30M  102M
  30M  102M
  30M  102M
  30M  103M
  29M  101M
  18M   61M
-net/total-
 recv  send
8112k   27M
8124k   27M
8084k   27M
9200k   31M
9855k   33M
9654k   33M
3973k   13M
```