### PR TITLE
Adding time.h to fix error on Windows. Fixes #76

### DIFF
--- a/src/haywire/http_response_cache.c
+++ b/src/haywire/http_response_cache.c
@@ -1,6 +1,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
+#include <time.h>
 #include "uv.h"
 #include "haywire.h"
 #include "hw_string.h"


### PR DESCRIPTION
This fixes #76 

Not having the include causes current time to be returned as negative and ctime to return a NULL value.