### PR TITLE
Removing static variable route_key that causes race condition between…

### DIFF
--- a/src/haywire/route_compare_method.c
+++ b/src/haywire/route_compare_method.c
@@ -9,8 +9,6 @@
     #define strtok_r strtok_s
 #endif
 
-static char route_key[2048];
-
 int hw_route_compare_method(char *url, char* route)
 {
     int equal = 0;
@@ -21,9 +19,7 @@ int hw_route_compare_method(char *url, char* route)
     char prefix;
     int match = 0;
     
-    strcpy(route_key, route);
-    
-    route_token = strtok_r(route_key, "/", &route_token_ptr);
+    route_token = strtok_r(route, "/", &route_token_ptr);
     request_token = strtok_r(url, "/", &request_token_ptr);
     
     while (route_token != NULL && request_token != NULL)
@@ -60,7 +56,7 @@ int hw_route_compare_method(char *url, char* route)
     if (!equal)
     {
         /* TODO: Remove strlen() call here and maybe replace with hw_string */
-        match = strncasecmp(route_key, url, strlen(route_key));
+        match = strncasecmp(route, url, strlen(route));
         if (!match)
         {
             equal = 1;
@@ -71,5 +67,6 @@ int hw_route_compare_method(char *url, char* route)
     {
         equal = 0;
     }
+    
     return equal;
 }


### PR DESCRIPTION
… threads.

In cases where the application is set-up to have multiple routes, the route_key string may be accessed by multiple threads and cause intermittent 404 errors (e.g. one thread would enter the function, write the value and then do all of its tests based on a different value written by a different thread).

I setup two routes: `/` and `/another`. Most of the requests are served just fine, but some fail with 404:
Here's an example of a 404 captured via tcpdump for a route that does exist: 

```
10:10:37.804816 IP (tos 0x0, ttl 64, id 48100, offset 0, flags [DF], proto TCP (6), length 94)
    ip-172-31-5-244.eu-west-1.compute.internal.42704 > ip-172-31-5-65.eu-west-1.compute.internal.irdmi: Flags [P.], cksum 0x63c4 (incorrect -> 0x125b), seq 85:127, ack 317, win 227,
 options [nop,nop,TS val 324257 ecr 173515], length 42
E..^..@.@..B.......A...@..I..$.g....c......
........GET / HTTP/1.1
Host: 172.31.5.65:8000


10:10:37.804921 IP (tos 0x0, ttl 64, id 21987, offset 0, flags [DF], proto TCP (6), length 212)
    ip-172-31-5-65.eu-west-1.compute.internal.irdmi > ip-172-31-5-244.eu-west-1.compute.internal.42704: Flags [P.], cksum 0x8a7a (correct), seq 317:477, ack 127, win 210, options [n
op,nop,TS val 173515 ecr 324257], length 160
E...U.@.@......A.....@...$.g..I......z.....
........HTTP/1.1 404 Not
Server: Haywire/master
Date: Thu Dec 17 10:10:37 2015
Content-Type: text/html
Connection: Keep-Alive
Content-Length: 16

404 Not Found
```

These changes I'm proposing have a marginal positive impact on performance (results on m4.xlarge on AWS with 4 service threads, using another m4.xlarge as client), as we don't need to do a `strcpy` anymore:

### Without fix
```
[ec2-user@ip-172-31-5-244 wrk]$ ./wrk -c 100 -t 100 -d 5s -s pipelined_get.lua --latency http://172.31.5.65:8000
Running 5s test @ http://172.31.5.65:8000
  100 threads and 100 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     1.31ms  159.20us  18.45ms   96.77%
    Req/Sec   761.14     67.25     2.12k    97.87%
  Latency Distribution
     50%    1.32ms
     75%    1.35ms
     90%    1.38ms
     99%    1.46ms
  384874 requests in 5.10s, 57.96MB read
Requests/sec:  75469.07
Transfer/sec:     11.37MB
```

### With fix
```
[ec2-user@ip-172-31-5-244 wrk]$ ./wrk -c 100 -t 100 -d 5s -s pipelined_get.lua --latency http://172.31.5.65:8000
Running 5s test @ http://172.31.5.65:8000
  100 threads and 100 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     1.30ms  153.82us  14.78ms   96.21%
    Req/Sec   765.15    114.88     3.32k    98.09%
  Latency Distribution
     50%    1.32ms
     75%    1.34ms
     90%    1.36ms
     99%    1.45ms
  386687 requests in 5.10s, 58.27MB read
Requests/sec:  75822.97
Transfer/sec:     11.43MB
```