### PR TITLE
Adding picohttpparser support.

### DIFF
--- a/include/haywire.h
+++ b/include/haywire.h
@@ -160,7 +160,6 @@ typedef struct
     hw_string* url;
     void* headers;
     hw_string* body;
-    int body_length;
 } http_request;
 
 typedef	void* hw_http_response;

--- a/src/haywire/connection_consumer.c
+++ b/src/haywire/connection_consumer.c
@@ -1,6 +1,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include "uv.h"
+#include "http.h"
 #include "connection_consumer.h"
 #include "http_server.h"
 #include "http_connection.h"

--- a/src/haywire/http.h
+++ b/src/haywire/http.h
@@ -1,0 +1,35 @@
+#pragma once
+#include "uv.h"
+#include "haywire.h"
+#include "http_parser.h"
+#include "http_request.h"
+
+typedef struct http_connection
+{
+    uv_tcp_t stream;
+    http_parser parser;
+    uv_write_t write_req;
+    http_request* request;
+    char current_header_key[1024];
+    int current_header_key_length;
+    char current_header_value[1024];
+    int current_header_value_length;
+    int keep_alive;
+    int last_was_value;
+    uv_buf_t response_buffers[1024];
+    int response_buffers_count;
+    int prevbuflen;
+    char* request_buffer;
+    int request_buffer_length;
+} http_connection;
+
+http_request* create_http_request(http_connection* connection);
+void free_http_request(http_request* request);
+int http_request_on_message_begin(http_parser *parser);
+int http_request_on_url(http_parser *parser, const char *at, size_t length);
+int http_request_on_header_field(http_parser *parser, const char *at, size_t length);
+int http_request_on_header_value(http_parser *parser, const char *at, size_t length);
+int http_request_on_body(http_parser *parser, const char *at, size_t length);
+int http_request_on_headers_complete(http_parser *parser);
+int http_request_on_message_complete(http_parser *parser);
+int http_request_complete_request(struct http_connection* connection);

--- a/src/haywire/http_connection.h
+++ b/src/haywire/http_connection.h
@@ -1,18 +1,2 @@
 #pragma once
-#include "uv.h"
-#include "http_parser.h"
-#include "http_request.h"
-
-typedef struct
-{
-    uv_tcp_t stream;
-    http_parser parser;
-    uv_write_t write_req;
-    http_request* request;
-    char current_header_key[1024];
-    int current_header_key_length;
-    char current_header_value[1024];
-    int current_header_value_length;
-    int keep_alive;
-    int last_was_value;
-} http_connection;
+#include "http.h"

--- a/src/haywire/http_request.c
+++ b/src/haywire/http_request.c
@@ -3,6 +3,7 @@
 #include <string.h>
 #include <ctype.h>
 #include "haywire.h"
+#include "http.h"
 #include "hw_string.h"
 #include "khash.h"
 #include "http_request.h"
@@ -61,12 +62,10 @@ void* get_header(http_request* request, char* name)
 http_request* create_http_request(http_connection* connection)
 {
     http_request* request = malloc(sizeof(http_request));
-    request->url = NULL;
     request->headers = kh_init(string_hashmap);
     request->url = malloc(sizeof(hw_string));
     request->url->length = 0;
     request->url->value = NULL;
-    request->body_length = 0;
     request->body = malloc(sizeof(hw_string));
     request->body->value = NULL;
     request->body->length = 0;
@@ -270,6 +269,11 @@ void get_404_response(http_request* request, http_response* response)
 int http_request_on_message_complete(http_parser* parser)
 {
     http_connection* connection = (http_connection*)parser->data;
+    return http_request_complete_request(connection);
+}
+
+int http_request_complete_request(struct http_connection* connection)
+{
     hw_route_entry* route_entry = get_route_callback(connection->request->url);
     hw_string* response_buffer;
     hw_write_context* write_context;

--- a/src/haywire/http_request.h
+++ b/src/haywire/http_request.h
@@ -1,14 +1,6 @@
 #pragma once
 #include "uv.h"
 #include "http_parser.h"
+#include "http_connection.h"
 
 extern int last_was_value;
-
-void free_http_request(http_request* request);
-int http_request_on_message_begin(http_parser *parser);
-int http_request_on_url(http_parser *parser, const char *at, size_t length);
-int http_request_on_header_field(http_parser *parser, const char *at, size_t length);
-int http_request_on_header_value(http_parser *parser, const char *at, size_t length);
-int http_request_on_body(http_parser *parser, const char *at, size_t length);
-int http_request_on_headers_complete(http_parser *parser);
-int http_request_on_message_complete(http_parser *parser);

--- a/src/haywire/http_server.h
+++ b/src/haywire/http_server.h
@@ -43,3 +43,4 @@ void http_stream_on_close(uv_handle_t* handle);
 int http_server_write_response_single(hw_write_context* write_context, hw_string* response);
 void http_server_after_write(uv_write_t* req, int status);
 void http_stream_on_read_http_parser(uv_stream_t* tcp, ssize_t nread, const uv_buf_t* buf);
+void http_stream_on_read_pico(uv_stream_t* tcp, ssize_t nread, const uv_buf_t* buf);

--- a/src/haywire/picohttpparser.c
+++ b/src/haywire/picohttpparser.c
@@ -1,0 +1,596 @@
+/*
+ * Copyright (c) 2009-2014 Kazuho Oku, Tokuhiro Matsuno, Daisuke Murase,
+ *                         Shigeo Mitsunari
+ *
+ * The software is licensed under either the MIT License (below) or the Perl
+ * license.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+#include <assert.h>
+#include <stddef.h>
+#include <string.h>
+#ifdef __SSE4_2__
+#ifdef _MSC_VER
+#include <nmmintrin.h>
+#else
+#include <x86intrin.h>
+#endif
+#endif
+#include "picohttpparser.h"
+
+/* $Id$ */
+
+#if __GNUC__ >= 3
+#define likely(x) __builtin_expect(!!(x), 1)
+#define unlikely(x) __builtin_expect(!!(x), 0)
+#else
+#define likely(x) (x)
+#define unlikely(x) (x)
+#endif
+
+#ifdef _MSC_VER
+#define ALIGNED(n) _declspec(align(n))
+#else
+#define ALIGNED(n) __attribute__((aligned(n)))
+#endif
+
+#define IS_PRINTABLE_ASCII(c) ((unsigned char)(c)-040u < 0137u)
+
+#define CHECK_EOF()                                                                                                                \
+    if (buf == buf_end) {                                                                                                          \
+        *ret = -2;                                                                                                                 \
+        return NULL;                                                                                                               \
+    }
+
+#define EXPECT_CHAR(ch)                                                                                                            \
+    CHECK_EOF();                                                                                                                   \
+    if (*buf++ != ch) {                                                                                                            \
+        *ret = -1;                                                                                                                 \
+        return NULL;                                                                                                               \
+    }
+
+#define ADVANCE_TOKEN(tok, toklen)                                                                                                 \
+    do {                                                                                                                           \
+        const char *tok_start = buf;                                                                                               \
+        static const char ALIGNED(16) ranges2[] = "\000\040\177\177";                                                              \
+        int found2;                                                                                                                \
+        buf = findchar_fast(buf, buf_end, ranges2, sizeof(ranges2) - 1, &found2);                                                  \
+        if (!found2) {                                                                                                             \
+            CHECK_EOF();                                                                                                           \
+        }                                                                                                                          \
+        while (1) {                                                                                                                \
+            if (*buf == ' ') {                                                                                                     \
+                break;                                                                                                             \
+            } else if (unlikely(!IS_PRINTABLE_ASCII(*buf))) {                                                                      \
+                if ((unsigned char)*buf < '\040' || *buf == '\177') {                                                              \
+                    *ret = -1;                                                                                                     \
+                    return NULL;                                                                                                   \
+                }                                                                                                                  \
+            }                                                                                                                      \
+            ++buf;                                                                                                                 \
+            CHECK_EOF();                                                                                                           \
+        }                                                                                                                          \
+        tok = tok_start;                                                                                                           \
+        toklen = buf - tok_start;                                                                                                  \
+    } while (0)
+
+static const char *token_char_map = "\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0"
+                                    "\0\1\1\1\1\1\1\1\0\0\1\1\0\1\1\0\1\1\1\1\1\1\1\1\1\1\0\0\0\0\0\0"
+                                    "\0\1\1\1\1\1\1\1\1\1\1\1\1\1\1\1\1\1\1\1\1\1\1\1\1\1\1\0\0\0\1\1"
+                                    "\1\1\1\1\1\1\1\1\1\1\1\1\1\1\1\1\1\1\1\1\1\1\1\1\1\1\1\0\1\0\1\0"
+                                    "\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0"
+                                    "\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0"
+                                    "\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0"
+                                    "\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0";
+
+static const char *findchar_fast(const char *buf, const char *buf_end, const char *ranges, size_t ranges_size, int *found)
+{
+    *found = 0;
+#if __SSE4_2__
+    if (likely(buf_end - buf >= 16)) {
+        __m128i ranges16 = _mm_loadu_si128((const __m128i *)ranges);
+
+        size_t left = (buf_end - buf) & ~15;
+        do {
+            __m128i b16 = _mm_loadu_si128((void *)buf);
+            int r = _mm_cmpestri(ranges16, ranges_size, b16, 16, _SIDD_LEAST_SIGNIFICANT | _SIDD_CMP_RANGES | _SIDD_UBYTE_OPS);
+            if (unlikely(r != 16)) {
+                buf += r;
+                *found = 1;
+                break;
+            }
+            buf += 16;
+            left -= 16;
+        } while (likely(left != 0));
+    }
+#endif
+    return buf;
+}
+
+static const char *get_token_to_eol(const char *buf, const char *buf_end, const char **token, size_t *token_len, int *ret)
+{
+    const char *token_start = buf;
+
+#ifdef __SSE4_2__
+    static const char ranges1[] = "\0\010"
+                                  /* allow HT */
+                                  "\012\037"
+                                  /* allow SP and up to but not including DEL */
+                                  "\177\177"
+        /* allow chars w. MSB set */
+        ;
+    int found;
+    buf = findchar_fast(buf, buf_end, ranges1, sizeof(ranges1) - 1, &found);
+    if (found)
+        goto FOUND_CTL;
+#else
+    /* find non-printable char within the next 8 bytes, this is the hottest code; manually inlined */
+    while (likely(buf_end - buf >= 8)) {
+#define DOIT()                                                                                                                     \
+    do {                                                                                                                           \
+        if (unlikely(!IS_PRINTABLE_ASCII(*buf)))                                                                                   \
+            goto NonPrintable;                                                                                                     \
+        ++buf;                                                                                                                     \
+    } while (0)
+        DOIT();
+        DOIT();
+        DOIT();
+        DOIT();
+        DOIT();
+        DOIT();
+        DOIT();
+        DOIT();
+#undef DOIT
+        continue;
+    NonPrintable:
+        if ((likely((unsigned char)*buf < '\040') && likely(*buf != '\011')) || unlikely(*buf == '\177')) {
+            goto FOUND_CTL;
+        }
+        ++buf;
+    }
+#endif
+    for (;; ++buf) {
+        CHECK_EOF();
+        if (unlikely(!IS_PRINTABLE_ASCII(*buf))) {
+            if ((likely((unsigned char)*buf < '\040') && likely(*buf != '\011')) || unlikely(*buf == '\177')) {
+                goto FOUND_CTL;
+            }
+        }
+    }
+FOUND_CTL:
+    if (likely(*buf == '\015')) {
+        ++buf;
+        EXPECT_CHAR('\012');
+        *token_len = buf - 2 - token_start;
+    } else if (*buf == '\012') {
+        *token_len = buf - token_start;
+        ++buf;
+    } else {
+        *ret = -1;
+        return NULL;
+    }
+    *token = token_start;
+
+    return buf;
+}
+
+static const char *is_complete(const char *buf, const char *buf_end, size_t last_len, int *ret)
+{
+    int ret_cnt = 0;
+    buf = last_len < 3 ? buf : buf + last_len - 3;
+
+    while (1) {
+        CHECK_EOF();
+        if (*buf == '\015') {
+            ++buf;
+            CHECK_EOF();
+            EXPECT_CHAR('\012');
+            ++ret_cnt;
+        } else if (*buf == '\012') {
+            ++buf;
+            ++ret_cnt;
+        } else {
+            ++buf;
+            ret_cnt = 0;
+        }
+        if (ret_cnt == 2) {
+            return buf;
+        }
+    }
+
+    *ret = -2;
+    return NULL;
+}
+
+/* *_buf is always within [buf, buf_end) upon success */
+static const char *parse_int(const char *buf, const char *buf_end, int *value, int *ret)
+{
+    int v;
+    CHECK_EOF();
+    if (!('0' <= *buf && *buf <= '9')) {
+        *ret = -1;
+        return NULL;
+    }
+    v = 0;
+    for (;; ++buf) {
+        CHECK_EOF();
+        if ('0' <= *buf && *buf <= '9') {
+            v = v * 10 + *buf - '0';
+        } else {
+            break;
+        }
+    }
+
+    *value = v;
+    return buf;
+}
+
+/* returned pointer is always within [buf, buf_end), or null */
+static const char *parse_http_version(const char *buf, const char *buf_end, int *minor_version, int *ret)
+{
+    EXPECT_CHAR('H');
+    EXPECT_CHAR('T');
+    EXPECT_CHAR('T');
+    EXPECT_CHAR('P');
+    EXPECT_CHAR('/');
+    EXPECT_CHAR('1');
+    EXPECT_CHAR('.');
+    return parse_int(buf, buf_end, minor_version, ret);
+}
+
+static const char *parse_headers(const char *buf, const char *buf_end, struct phr_header *headers, size_t *num_headers,
+                                 size_t max_headers, int *ret)
+{
+    for (;; ++*num_headers) {
+        CHECK_EOF();
+        if (*buf == '\015') {
+            ++buf;
+            EXPECT_CHAR('\012');
+            break;
+        } else if (*buf == '\012') {
+            ++buf;
+            break;
+        }
+        if (*num_headers == max_headers) {
+            *ret = -1;
+            return NULL;
+        }
+        if (!(*num_headers != 0 && (*buf == ' ' || *buf == '\t'))) {
+            if (!token_char_map[(unsigned char)*buf]) {
+                *ret = -1;
+                return NULL;
+            }
+            /* parsing name, but do not discard SP before colon, see
+             * http://www.mozilla.org/security/announce/2006/mfsa2006-33.html */
+            headers[*num_headers].name = buf;
+            static const char ALIGNED(16) ranges1[] = "::\x00\037";
+            int found;
+            buf = findchar_fast(buf, buf_end, ranges1, sizeof(ranges1) - 1, &found);
+            if (!found) {
+                CHECK_EOF();
+            }
+            while (1) {
+                if (*buf == ':') {
+                    break;
+                } else if (*buf < ' ') {
+                    *ret = -1;
+                    return NULL;
+                }
+                ++buf;
+                CHECK_EOF();
+            }
+            headers[*num_headers].name_len = buf - headers[*num_headers].name;
+            ++buf;
+            for (;; ++buf) {
+                CHECK_EOF();
+                if (!(*buf == ' ' || *buf == '\t')) {
+                    break;
+                }
+            }
+        } else {
+            headers[*num_headers].name = NULL;
+            headers[*num_headers].name_len = 0;
+        }
+        if ((buf = get_token_to_eol(buf, buf_end, &headers[*num_headers].value, &headers[*num_headers].value_len, ret)) == NULL) {
+            return NULL;
+        }
+    }
+    return buf;
+}
+
+static const char *parse_request(const char *buf, const char *buf_end, const char **method, size_t *method_len, const char **path,
+                                 size_t *path_len, int *minor_version, struct phr_header *headers, size_t *num_headers,
+                                 size_t max_headers, int *ret)
+{
+    /* skip first empty line (some clients add CRLF after POST content) */
+    CHECK_EOF();
+    if (*buf == '\015') {
+        ++buf;
+        EXPECT_CHAR('\012');
+    } else if (*buf == '\012') {
+        ++buf;
+    }
+
+    /* parse request line */
+    ADVANCE_TOKEN(*method, *method_len);
+    ++buf;
+    ADVANCE_TOKEN(*path, *path_len);
+    ++buf;
+    if ((buf = parse_http_version(buf, buf_end, minor_version, ret)) == NULL) {
+        return NULL;
+    }
+    if (*buf == '\015') {
+        ++buf;
+        EXPECT_CHAR('\012');
+    } else if (*buf == '\012') {
+        ++buf;
+    } else {
+        *ret = -1;
+        return NULL;
+    }
+
+    return parse_headers(buf, buf_end, headers, num_headers, max_headers, ret);
+}
+
+int phr_parse_request(const char *buf_start, size_t len, const char **method, size_t *method_len, const char **path,
+                      size_t *path_len, int *minor_version, struct phr_header *headers, size_t *num_headers, size_t last_len)
+{
+    const char *buf = buf_start, *buf_end = buf_start + len;
+    size_t max_headers = *num_headers;
+    int r;
+
+    *method = NULL;
+    *method_len = 0;
+    *path = NULL;
+    *path_len = 0;
+    *minor_version = -1;
+    *num_headers = 0;
+
+    /* if last_len != 0, check if the request is complete (a fast countermeasure
+       againt slowloris */
+    if (last_len != 0 && is_complete(buf, buf_end, last_len, &r) == NULL) {
+        return r;
+    }
+
+    if ((buf = parse_request(buf, buf_end, method, method_len, path, path_len, minor_version, headers, num_headers, max_headers,
+                             &r)) == NULL) {
+        return r;
+    }
+
+    return (int)(buf - buf_start);
+}
+
+static const char *parse_response(const char *buf, const char *buf_end, int *minor_version, int *status, const char **msg,
+                                  size_t *msg_len, struct phr_header *headers, size_t *num_headers, size_t max_headers, int *ret)
+{
+    /* parse "HTTP/1.x" */
+    if ((buf = parse_http_version(buf, buf_end, minor_version, ret)) == NULL) {
+        return NULL;
+    }
+    /* skip space */
+    if (*buf++ != ' ') {
+        *ret = -1;
+        return NULL;
+    }
+    /* parse status code */
+    if ((buf = parse_int(buf, buf_end, status, ret)) == NULL) {
+        return NULL;
+    }
+    /* skip space */
+    if (*buf++ != ' ') {
+        *ret = -1;
+        return NULL;
+    }
+    /* get message */
+    if ((buf = get_token_to_eol(buf, buf_end, msg, msg_len, ret)) == NULL) {
+        return NULL;
+    }
+
+    return parse_headers(buf, buf_end, headers, num_headers, max_headers, ret);
+}
+
+int phr_parse_response(const char *buf_start, size_t len, int *minor_version, int *status, const char **msg, size_t *msg_len,
+                       struct phr_header *headers, size_t *num_headers, size_t last_len)
+{
+    const char *buf = buf_start, *buf_end = buf + len;
+    size_t max_headers = *num_headers;
+    int r;
+
+    *minor_version = -1;
+    *status = 0;
+    *msg = NULL;
+    *msg_len = 0;
+    *num_headers = 0;
+
+    /* if last_len != 0, check if the response is complete (a fast countermeasure
+       against slowloris */
+    if (last_len != 0 && is_complete(buf, buf_end, last_len, &r) == NULL) {
+        return r;
+    }
+
+    if ((buf = parse_response(buf, buf_end, minor_version, status, msg, msg_len, headers, num_headers, max_headers, &r)) == NULL) {
+        return r;
+    }
+
+    return (int)(buf - buf_start);
+}
+
+int phr_parse_headers(const char *buf_start, size_t len, struct phr_header *headers, size_t *num_headers, size_t last_len)
+{
+    const char *buf = buf_start, *buf_end = buf + len;
+    size_t max_headers = *num_headers;
+    int r;
+
+    *num_headers = 0;
+
+    /* if last_len != 0, check if the response is complete (a fast countermeasure
+       against slowloris */
+    if (last_len != 0 && is_complete(buf, buf_end, last_len, &r) == NULL) {
+        return r;
+    }
+
+    if ((buf = parse_headers(buf, buf_end, headers, num_headers, max_headers, &r)) == NULL) {
+        return r;
+    }
+
+    return (int)(buf - buf_start);
+}
+
+enum {
+    CHUNKED_IN_CHUNK_SIZE,
+    CHUNKED_IN_CHUNK_EXT,
+    CHUNKED_IN_CHUNK_DATA,
+    CHUNKED_IN_CHUNK_CRLF,
+    CHUNKED_IN_TRAILERS_LINE_HEAD,
+    CHUNKED_IN_TRAILERS_LINE_MIDDLE
+};
+
+static int decode_hex(int ch)
+{
+    if ('0' <= ch && ch <= '9') {
+        return ch - '0';
+    } else if ('A' <= ch && ch <= 'F') {
+        return ch - 'A' + 0xa;
+    } else if ('a' <= ch && ch <= 'f') {
+        return ch - 'a' + 0xa;
+    } else {
+        return -1;
+    }
+}
+
+ssize_t phr_decode_chunked(struct phr_chunked_decoder *decoder, char *buf, size_t *_bufsz)
+{
+    size_t dst = 0, src = 0, bufsz = *_bufsz;
+    ssize_t ret = -2; /* incomplete */
+
+    while (1) {
+        switch (decoder->_state) {
+        case CHUNKED_IN_CHUNK_SIZE:
+            for (;; ++src) {
+                int v;
+                if (src == bufsz)
+                    goto Exit;
+                if ((v = decode_hex(buf[src])) == -1) {
+                    if (decoder->_hex_count == 0) {
+                        ret = -1;
+                        goto Exit;
+                    }
+                    break;
+                }
+                if (decoder->_hex_count == sizeof(size_t) * 2) {
+                    ret = -1;
+                    goto Exit;
+                }
+                decoder->bytes_left_in_chunk = decoder->bytes_left_in_chunk * 16 + v;
+                ++decoder->_hex_count;
+            }
+            decoder->_hex_count = 0;
+            decoder->_state = CHUNKED_IN_CHUNK_EXT;
+        /* fallthru */
+        case CHUNKED_IN_CHUNK_EXT:
+            /* RFC 7230 A.2 "Line folding in chunk extensions is disallowed" */
+            for (;; ++src) {
+                if (src == bufsz)
+                    goto Exit;
+                if (buf[src] == '\012')
+                    break;
+            }
+            ++src;
+            if (decoder->bytes_left_in_chunk == 0) {
+                if (decoder->consume_trailer) {
+                    decoder->_state = CHUNKED_IN_TRAILERS_LINE_HEAD;
+                    break;
+                } else {
+                    goto Complete;
+                }
+            }
+            decoder->_state = CHUNKED_IN_CHUNK_DATA;
+        /* fallthru */
+        case CHUNKED_IN_CHUNK_DATA: {
+            size_t avail = bufsz - src;
+            if (avail < decoder->bytes_left_in_chunk) {
+                if (dst != src)
+                    memmove(buf + dst, buf + src, avail);
+                src += avail;
+                dst += avail;
+                decoder->bytes_left_in_chunk -= avail;
+                goto Exit;
+            }
+            if (dst != src)
+                memmove(buf + dst, buf + src, decoder->bytes_left_in_chunk);
+            src += decoder->bytes_left_in_chunk;
+            dst += decoder->bytes_left_in_chunk;
+            decoder->bytes_left_in_chunk = 0;
+            decoder->_state = CHUNKED_IN_CHUNK_CRLF;
+        }
+        /* fallthru */
+        case CHUNKED_IN_CHUNK_CRLF:
+            for (;; ++src) {
+                if (src == bufsz)
+                    goto Exit;
+                if (buf[src] != '\015')
+                    break;
+            }
+            if (buf[src] != '\012') {
+                ret = -1;
+                goto Exit;
+            }
+            ++src;
+            decoder->_state = CHUNKED_IN_CHUNK_SIZE;
+            break;
+        case CHUNKED_IN_TRAILERS_LINE_HEAD:
+            for (;; ++src) {
+                if (src == bufsz)
+                    goto Exit;
+                if (buf[src] != '\015')
+                    break;
+            }
+            if (buf[src++] == '\012')
+                goto Complete;
+            decoder->_state = CHUNKED_IN_TRAILERS_LINE_MIDDLE;
+        /* fallthru */
+        case CHUNKED_IN_TRAILERS_LINE_MIDDLE:
+            for (;; ++src) {
+                if (src == bufsz)
+                    goto Exit;
+                if (buf[src] == '\012')
+                    break;
+            }
+            ++src;
+            decoder->_state = CHUNKED_IN_TRAILERS_LINE_HEAD;
+            break;
+        default:
+            assert(!"decoder is corrupt");
+        }
+    }
+
+Complete:
+    ret = bufsz - src;
+Exit:
+    if (dst != src)
+        memmove(buf + dst, buf + src, bufsz - src);
+    *_bufsz = dst;
+    return ret;
+}
+
+#undef CHECK_EOF
+#undef EXPECT_CHAR
+#undef ADVANCE_TOKEN

--- a/src/haywire/picohttpparser.h
+++ b/src/haywire/picohttpparser.h
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2009-2014 Kazuho Oku, Tokuhiro Matsuno, Daisuke Murase,
+ *                         Shigeo Mitsunari
+ *
+ * The software is licensed under either the MIT License (below) or the Perl
+ * license.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+#ifndef picohttpparser_h
+#define picohttpparser_h
+
+#include <sys/types.h>
+
+#ifdef _MSC_VER
+#define ssize_t intptr_t
+#endif
+
+/* $Id$ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* contains name and value of a header (name == NULL if is a continuing line
+ * of a multiline header */
+struct phr_header {
+    const char *name;
+    size_t name_len;
+    const char *value;
+    size_t value_len;
+};
+
+/* returns number of bytes consumed if successful, -2 if request is partial,
+ * -1 if failed */
+int phr_parse_request(const char *buf, size_t len, const char **method, size_t *method_len, const char **path, size_t *path_len,
+                      int *minor_version, struct phr_header *headers, size_t *num_headers, size_t last_len);
+
+/* ditto */
+int phr_parse_response(const char *_buf, size_t len, int *minor_version, int *status, const char **msg, size_t *msg_len,
+                       struct phr_header *headers, size_t *num_headers, size_t last_len);
+
+/* ditto */
+int phr_parse_headers(const char *buf, size_t len, struct phr_header *headers, size_t *num_headers, size_t last_len);
+
+/* should be zero-filled before start */
+struct phr_chunked_decoder {
+    size_t bytes_left_in_chunk; /* number of bytes left in current chunk */
+    char consume_trailer;       /* if trailing headers should be consumed */
+    char _hex_count;
+    char _state;
+};
+
+/* the function rewrites the buffer given as (buf, bufsz) removing the chunked-
+ * encoding headers.  When the function returns without an error, bufsz is
+ * updated to the length of the decoded data available.  Applications should
+ * repeatedly call the function while it returns -2 (incomplete) every time
+ * supplying newly arrived data.  If the end of the chunked-encoded data is
+ * found, the function returns a non-negative number indicating the number of
+ * octets left undecoded at the tail of the supplied buffer.  Returns -1 on
+ * error.
+ */
+ssize_t phr_decode_chunked(struct phr_chunked_decoder *decoder, char *buf, size_t *bufsz);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif


### PR DESCRIPTION
Trying to create a smaller scoped PR for adding `picohttpparser` support to `master`. Experiencing some memory leaks though.

```
==13307==
==13307== HEAP SUMMARY:
==13307==     in use at exit: 30,715,957 bytes in 12,671 blocks
==13307==   total heap usage: 771,707 allocs, 759,036 frees, 570,372,132 bytes allocated
==13307==
==13307== 16 bytes in 1 blocks are definitely lost in loss record 11 of 59
==13307==    at 0x4C2BBA0: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==13307==    by 0x407C60: opt_config_parse (parse.c:23)
==13307==    by 0x40772E: main (program.c:60)
==13307==
==13307== 128 bytes in 1 blocks are possibly lost in loss record 26 of 59
==13307==    at 0x4C2BBA0: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==13307==    by 0x40B5C6: hw_http_open (http_server.c:192)
==13307==    by 0x40774E: main (program.c:65)
==13307==
==13307== 6,080 bytes in 40 blocks are possibly lost in loss record 41 of 59
==13307==    at 0x4C2BBA0: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==13307==    by 0x409733: http_request_cache_configure_listener (http_response_cache.c:32)
==13307==    by 0x40CB47: connection_consumer_start (connection_consumer.c:114)
==13307==    by 0x418AE6: uv__thread_start (thread.c:50)
==13307==    by 0x4E3F6A9: start_thread (pthread_create.c:333)
==13307==
==13307== 22,400 bytes in 40 blocks are possibly lost in loss record 44 of 59
==13307==    at 0x4C2DC90: calloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==13307==    by 0x40134B4: allocate_dtv (dl-tls.c:322)
==13307==    by 0x40134B4: _dl_allocate_tls (dl-tls.c:544)
==13307==    by 0x4E400D2: allocate_stack (allocatestack.c:588)
==13307==    by 0x4E400D2: pthread_create@@GLIBC_2.2.5 (pthread_create.c:537)
==13307==    by 0x418B2D: uv_thread_create (thread.c:92)
==13307==    by 0x40B6C5: hw_http_open (http_server.c:230)
==13307==    by 0x40774E: main (program.c:65)
==13307==
==13307== 86,832 bytes in 3,618 blocks are possibly lost in loss record 51 of 59
==13307==    at 0x4C2BBA0: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==13307==    by 0x4092BA: hw_http_response_send (http_request.c:307)
==13307==    by 0x4080B4: get_root (program.c:45)
==13307==    by 0x409210: http_request_complete_request (http_request.c:285)
==13307==    by 0x40A723: http_stream_on_read_pico (http_server.c:337)
==13307==    by 0x4169EF: uv__read (stream.c:1183)
==13307==    by 0x41716B: uv__stream_io (stream.c:1250)
==13307==    by 0x41B6A9: uv__io_poll (linux-core.c:345)
==13307==    by 0x412117: uv_run (core.c:351)
==13307==    by 0x40CBAD: connection_consumer_start (connection_consumer.c:126)
==13307==    by 0x418AE6: uv__thread_start (thread.c:50)
==13307==    by 0x4E3F6A9: start_thread (pthread_create.c:333)
==13307==
==13307== 752,752 bytes in 3,619 blocks are possibly lost in loss record 53 of 59
==13307==    at 0x4C2BBA0: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==13307==    by 0x40A885: http_server_write_response_single (http_server.c:368)
==13307==    by 0x4092E3: hw_http_response_send (http_request.c:314)
==13307==    by 0x4080B4: get_root (program.c:45)
==13307==    by 0x409210: http_request_complete_request (http_request.c:285)
==13307==    by 0x40A723: http_stream_on_read_pico (http_server.c:337)
==13307==    by 0x4169EF: uv__read (stream.c:1183)
==13307==    by 0x41716B: uv__stream_io (stream.c:1250)
==13307==    by 0x41B6A9: uv__io_poll (linux-core.c:345)
==13307==    by 0x412117: uv_run (core.c:351)
==13307==    by 0x40CBAD: connection_consumer_start (connection_consumer.c:126)
==13307==    by 0x418AE6: uv__thread_start (thread.c:50)
==13307==
==13307== 2,000,494 bytes in 3,611 blocks are possibly lost in loss record 56 of 59
==13307==    at 0x4C2BBA0: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==13307==    by 0x40952A: create_response_buffer (http_response.c:89)
==13307==    by 0x4092C5: hw_http_response_send (http_request.c:309)
==13307==    by 0x4080B4: get_root (program.c:45)
==13307==    by 0x409210: http_request_complete_request (http_request.c:285)
==13307==    by 0x40A723: http_stream_on_read_pico (http_server.c:337)
==13307==    by 0x4169EF: uv__read (stream.c:1183)
==13307==    by 0x41716B: uv__stream_io (stream.c:1250)
==13307==    by 0x41B6A9: uv__io_poll (linux-core.c:345)
==13307==    by 0x412117: uv_run (core.c:351)
==13307==    by 0x40CBAD: connection_consumer_start (connection_consumer.c:126)
==13307==    by 0x418AE6: uv__thread_start (thread.c:50)
==13307==
==13307== 8,300,976 bytes in 438 blocks are possibly lost in loss record 58 of 59
==13307==    at 0x4C2BBA0: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==13307==    by 0x40AA3A: create_http_connection (http_server.c:109)
==13307==    by 0x40C9EF: connection_consumer_new_connection (connection_consumer.c:66)
==13307==    by 0x41772F: uv__server_io (stream.c:551)
==13307==    by 0x41B6A9: uv__io_poll (linux-core.c:345)
==13307==    by 0x412117: uv_run (core.c:351)
==13307==    by 0x40CBAD: connection_consumer_start (connection_consumer.c:126)
==13307==    by 0x418AE6: uv__thread_start (thread.c:50)
==13307==    by 0x4E3F6A9: start_thread (pthread_create.c:333)
==13307==
==13307== 14,352,384 bytes in 438 blocks are possibly lost in loss record 59 of 59
==13307==    at 0x4C2DC90: calloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==13307==    by 0x40AA57: create_http_connection (http_server.c:111)
==13307==    by 0x40C9EF: connection_consumer_new_connection (connection_consumer.c:66)
==13307==    by 0x41772F: uv__server_io (stream.c:551)
==13307==    by 0x41B6A9: uv__io_poll (linux-core.c:345)
==13307==    by 0x412117: uv_run (core.c:351)
==13307==    by 0x40CBAD: connection_consumer_start (connection_consumer.c:126)
==13307==    by 0x418AE6: uv__thread_start (thread.c:50)
==13307==    by 0x4E3F6A9: start_thread (pthread_create.c:333)
==13307==
```