### PR TITLE
Adding request start time on Linux.

### DIFF
--- a/include/haywire.h
+++ b/include/haywire.h
@@ -163,7 +163,7 @@ typedef struct
     hw_string* body;
     int body_length;
 #ifdef __linux__
-    struct timespec* start_time;
+    long start_time_micros;
 #endif
 } http_request;
 

--- a/include/haywire.h
+++ b/include/haywire.h
@@ -6,6 +6,7 @@ extern "C" {
 
 #include <stdio.h>
 #include <stdbool.h>
+#include <time.h>
 
 #ifdef _WIN32
     /* Windows - set up dll import/export decorators. */
@@ -161,6 +162,9 @@ typedef struct
     void* headers;
     hw_string* body;
     int body_length;
+#ifdef __linux__
+    struct timespec* start_time;
+#endif
 } http_request;
 
 typedef	void* hw_http_response;

--- a/src/haywire/http_request.c
+++ b/src/haywire/http_request.c
@@ -101,6 +101,10 @@ http_request* create_http_request(http_connection* connection)
     request->body = malloc(sizeof(hw_string));
     request->body->value = NULL;
     request->body->length = 0;
+#ifdef __linux__
+    request->start_time = malloc(sizeof(struct timespec));
+    clock_gettime(CLOCK_REALTIME, request->start_time);
+#endif
     INCREMENT_STAT(stat_requests_created_total);
     return request;
 }
@@ -123,6 +127,9 @@ void free_http_request(http_request* request)
     }
     free(request->url); 
     free(request->body);
+#ifdef __linux__
+    free(request->start_time);
+#endif
     free(request);
     INCREMENT_STAT(stat_requests_destroyed_total);
 }

--- a/src/haywire/http_request.c
+++ b/src/haywire/http_request.c
@@ -102,8 +102,9 @@ http_request* create_http_request(http_connection* connection)
     request->body->value = NULL;
     request->body->length = 0;
 #ifdef __linux__
-    request->start_time = malloc(sizeof(struct timespec));
-    clock_gettime(CLOCK_REALTIME, request->start_time);
+    struct timeval t;
+    gettimeofday(&t, NULL);
+    request->start_time_micros = (t.tv_sec * 1000000) + t.tv_usec;
 #endif
     INCREMENT_STAT(stat_requests_created_total);
     return request;
@@ -127,9 +128,6 @@ void free_http_request(http_request* request)
     }
     free(request->url); 
     free(request->body);
-#ifdef __linux__
-    free(request->start_time);
-#endif
     free(request);
     INCREMENT_STAT(stat_requests_destroyed_total);
 }


### PR DESCRIPTION
This has no significant performance impact as far as I can see (after switching to gettimeofday):
### master

```
[ec2-user@ip-172-31-5-244 wrk]$ ./wrk -c 50 -t 50 -d 10s -s pipelined_get.lua  --latency http://172.31.5.65:8000 -- 64
Running 10s test @ http://172.31.5.65:8000
  50 threads and 50 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     2.42ms    1.50ms  40.03ms   60.71%
    Req/Sec    14.47k     4.58k   53.01k    77.62%
  Latency Distribution
     50%    2.47ms
     75%    3.96ms
     90%    5.54ms
     99%    0.00us
  7266329 requests in 10.09s, 1.19GB read
Requests/sec: 720072.32
Transfer/sec:    120.86MB
```
### this branch

```
Running 10s test @ http://172.31.5.65:8000
  50 threads and 50 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     2.51ms    1.55ms  25.95ms   57.70%
    Req/Sec    14.47k     5.68k   54.31k    81.64%
  Latency Distribution
     50%    2.59ms
     75%    4.26ms
     90%    5.65ms
     99%    0.00us
  7266703 requests in 10.09s, 1.19GB read
Requests/sec: 719979.96
Transfer/sec:    120.85MB
```
