### PR TITLE
Fixing cached http response status that was being truncated due to in…

### DIFF
--- a/src/haywire/http_response_cache.c
+++ b/src/haywire/http_response_cache.c
@@ -2,6 +2,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <time.h>
+#include <haywire.h>
 #include "uv.h"
 #include "haywire.h"
 #include "hw_string.h"
@@ -18,9 +19,9 @@ static uv_key_t thread_cache_key;
 void initialize_http_request_cache();
 void free_http_request_cache();
 void http_request_cache_timer(uv_timer_t* handle);
-void create_cached_http_request(khash_t(string_hashmap)* http_request_cache, char* http_status);
+void create_cached_http_request(khash_t(string_hashmap)* http_request_cache, const char* http_status);
 void set_cached_request(khash_t(string_hashmap)* http_request_cache, char* http_status, hw_string* cache_entry);
-hw_string* get_cached_request(char* http_status);
+hw_string* get_cached_request(const char* http_status);
 
 void initialize_http_request_cache()
 {
@@ -64,14 +65,17 @@ void free_http_request_cache(khash_t(string_hashmap)* http_request_cache)
     uv_key_set(&thread_cache_key, NULL);
 }
 
-void create_cached_http_request(khash_t(string_hashmap)* http_request_cache, char* http_status)
+void create_cached_http_request(khash_t(string_hashmap)* http_request_cache, const char* http_status)
 {
     hw_string* cache_entry = malloc(sizeof(hw_string));
     cache_entry->value = calloc(1024, 1);
     cache_entry->length = 0;
+    hw_string status;
+    status.length = strlen(http_status);
+    status.value = http_status;
     
     append_string(cache_entry, http_v1_1);
-    APPENDSTRING(cache_entry, http_status);
+    append_string(cache_entry, &status);
     APPENDSTRING(cache_entry, CRLF);
     append_string(cache_entry, server_name);
     APPENDSTRING(cache_entry, CRLF);
@@ -105,7 +109,6 @@ void set_cached_request(khash_t(string_hashmap)* http_request_cache, char* http_
         
         if (!is_missing)
         {
-            printf("FOUND\n");
             //kh_del(string_hashmap, http_request_cache, key);
         }
     }
@@ -114,7 +117,7 @@ void set_cached_request(khash_t(string_hashmap)* http_request_cache, char* http_
     kh_value(http_request_cache, key) = cache_entry;
 }
 
-hw_string* get_cached_request(char* http_status)
+hw_string* get_cached_request(const char* http_status)
 {
     int is_missing;
     void* val;
@@ -127,7 +130,6 @@ hw_string* get_cached_request(char* http_status)
     {
         http_request_cache = kh_init(string_hashmap);
         uv_key_set(&thread_cache_key, http_request_cache);
-        //printf("CREATED CACHE\n");
     }
     
     key = kh_get(string_hashmap, http_request_cache, http_status);

--- a/src/haywire/http_response_cache.h
+++ b/src/haywire/http_response_cache.h
@@ -3,5 +3,5 @@
 #include "haywire.h"
 
 void initialize_http_request_cache();
-hw_string* get_cached_request(char* http_status);
+hw_string* get_cached_request(const char* http_status);
 void http_request_cache_configure_listener(uv_loop_t* loop, uv_async_t* handle);

--- a/src/haywire/hw_string.c
+++ b/src/haywire/hw_string.c
@@ -27,7 +27,7 @@ int hw_strcmp(hw_string* a, hw_string* b) {
 
 void append_string(hw_string* destination, hw_string* source)
 {
-    void* location = (char*)destination->value + destination->length;
+    void* location = (void*) (destination->value + destination->length);
     memcpy(location, source->value, source->length);
     destination->length += source->length;
 }


### PR DESCRIPTION
…correct usage of sizeof on char*

404 response before:

```
curl localhost:8000/bla -v
* About to connect() to localhost port 8000 (#0)
*   Trying ::1... Connection refused
*   Trying 127.0.0.1... connected
* Connected to localhost (127.0.0.1) port 8000 (#0)
> GET /bla HTTP/1.1
> User-Agent: curl/7.19.7 (x86_64-redhat-linux-gnu) libcurl/7.19.7 NSS/3.19.1 Basic ECC zlib/1.2.3 libidn/1.18 libssh2/1.4.2
> Host: localhost:8000
> Accept: */*
> 
< HTTP/1.1 404 Not
< Server: Haywire/master
< Date: Thu Feb 11 11:28:33 2016
< Content-Type: text/html
< Connection: Keep-Alive
< Content-Length: 13
< 
* Connection #0 to host localhost left intact
* Closing connection #0
```

with the change:

```
curl localhost:8000/bla -v
* About to connect() to localhost port 8000 (#0)
*   Trying ::1... Connection refused
*   Trying 127.0.0.1... connected
* Connected to localhost (127.0.0.1) port 8000 (#0)
> GET /bla HTTP/1.1
> User-Agent: curl/7.19.7 (x86_64-redhat-linux-gnu) libcurl/7.19.7 NSS/3.19.1 Basic ECC zlib/1.2.3 libidn/1.18 libssh2/1.4.2
> Host: localhost:8000
> Accept: */*
> 
< HTTP/1.1 404 Not Found
< Server: Haywire/master
< Date: Thu Feb 11 11:32:53 2016
< Content-Type: text/html
< Connection: Keep-Alive
< Content-Length: 13
< 
* Connection #0 to host localhost left intact
* Closing connection #0
```

I must say I didn't bother doing a benchmark as we only run this code once per status code, so the overhead of calling strlen is not significant.
