### PR TITLE
Ability to disable HTTP Routing

### DIFF
--- a/include/haywire.h
+++ b/include/haywire.h
@@ -176,6 +176,7 @@ HAYWIRE_EXTERN int hw_init_from_config(char* configuration_filename);
 HAYWIRE_EXTERN int hw_init_with_config(configuration* config);
 HAYWIRE_EXTERN int hw_http_open();
 HAYWIRE_EXTERN void hw_http_add_route(char* route, http_request_callback callback, void* user_data);
+HAYWIRE_EXTERN void hw_disable_http_routing(http_request_callback request_callback);
 HAYWIRE_EXTERN hw_string* hw_get_header(http_request* request, hw_string* key);
 
 HAYWIRE_EXTERN void hw_free_http_response(hw_http_response* response);

--- a/src/haywire/http_server.h
+++ b/src/haywire/http_server.h
@@ -18,6 +18,7 @@ union stream_handle
 };
 
 extern void* routes;
+extern http_request_callback root_request_callback;
 extern uv_loop_t* uv_loop;
 extern hw_string* http_v1_0;
 extern hw_string* http_v1_1;


### PR DESCRIPTION
This PR adds the ability to disable http routing in Haywire and route all requests to a single callback (root_request_callback). The common usage scenario I envision for this feature is operating other http frameworks that include their own routing, on top of Haywire. One example would be ASP.NET Core MVC, the root_request_callback would start ASP.NET Core’s middleware pipeline, and MVC would handle the routing.