### PR TITLE
docs: fix simple typo, recieving -> receiving

### DIFF
--- a/src/haywire/http_parser.c
+++ b/src/haywire/http_parser.c
@@ -1796,7 +1796,7 @@ size_t http_parser_execute (http_parser *parser,
                 /* Here we call the headers_complete callback. This is somewhat
                  * different than other callbacks because if the user returns 1, we
                  * will interpret that as saying that this message has no body. This
-                 * is needed for the annoying case of recieving a response to a HEAD
+                 * is needed for the annoying case of receiving a response to a HEAD
                  * request.
                  *
                  * We'd like to use CALLBACK_NOTIFY_NOADVANCE() here but we cannot, so


### PR DESCRIPTION
There is a small typo in src/haywire/http_parser.c.

Should read `receiving` rather than `recieving`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md